### PR TITLE
Update mythtv-backend image to 18.04 bionic, move off port 80

### DIFF
--- a/images/mythtv-backend/Dockerfile
+++ b/images/mythtv-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 MAINTAINER Rich Braun "docker@instantlinux.net"
 ARG BUILD_DATE
 ARG VCS_REF
@@ -28,7 +28,7 @@ ARG MYTHWEB_PORT=6760
 RUN \
   apt-get -yq update && apt-get install -yq gnupg locales wget && \
   apt-key adv --recv-keys --keyserver keyserver.ubuntu.com $APT_KEY && \
-  echo "deb http://ppa.launchpad.net/mythbuntu/$MYTHTV_VERSION/ubuntu xenial main" \
+  echo "deb http://ppa.launchpad.net/mythbuntu/$MYTHTV_VERSION/ubuntu bionic main" \
     > /etc/apt/sources.list.d/mythbuntu.list && \
   apt-get -yq update && \
   locale-gen $LANG && \
@@ -41,14 +41,16 @@ RUN \
 COPY src/ /root/
 
 RUN \
-  echo "Listen $MYTHWEB_PORT" >>/etc/apache2/ports.conf && \
-  sed -i -e "s/Port 22/Port $SSH_PORT/" /etc/ssh/sshd_config && \
+  sed -i -e "s/Listen 80/Listen $MYTHWEB_PORT/" /etc/apache2/ports.conf && \
+  sed -i -e "s/#Port 22/Port $SSH_PORT/" /etc/ssh/sshd_config && \
   mv /root/mythweb.conf /root/mythweb-settings.conf \
     /etc/apache2/sites-available/ && \
   usermod -u $MYTHTV_UID -s /bin/bash mythtv && \
   mkdir -p /var/lib/mythtv $APACHE_LOG_DIR && \
   echo "mythtv:mythtv" | chpasswd && \
   chown $MYTHTV_UID:$MYTHTV_GID /var/lib/mythtv
+RUN \
+  cat /etc/apache2/ports.conf
 
 EXPOSE $MYTHWEB_PORT $SSH_PORT 5000/udp 5002/udp 5004/udp 6543 6544 65001 \
   65001/udp 

--- a/images/mythtv-backend/README.md
+++ b/images/mythtv-backend/README.md
@@ -15,6 +15,12 @@ docker exec mythtvbackend_app_1 /usr/sbin/sshd
 ssh -p 2022 -X mythtv@<host-ip>
 mythtv-setup
 ~~~
+
+If you're performing setup from a multi monitor system, the fullscreen mythtv-setup might not be entirely visible. In this case, use the following to limit the resolution
+~~~
+mythtv-setup -w -geometry 1280x720
+~~~
+
 Change the password by generating a new hashed password and setting mythtv-user-password secret.
 
 Look for MythTV status pages on port 6544, and MythWeb is serviced on 6760.

--- a/images/mythtv-backend/README.md
+++ b/images/mythtv-backend/README.md
@@ -1,13 +1,26 @@
 ## mythtv-backend
 [![](https://images.microbadger.com/badges/version/instantlinux/mythtv-backend.svg)](https://microbadger.com/images/instantlinux/mythtv-backend "Version badge") [![](https://images.microbadger.com/badges/image/instantlinux/mythtv-backend.svg)](https://microbadger.com/images/instantlinux/mythtv-backend "Image badge") [![](https://images.microbadger.com/badges/commit/instantlinux/mythtv-backend.svg)](https://microbadger.com/images/instantlinux/mythtv-backend "Commit badge")
 
-The MythTV backend built under Ubuntu 16.04 LTS.
+The MythTV backend built under Ubuntu 18.04 LTS.
 
 ### Usage
 
 This image must be run in network_mode:host in order to communicate with HD Homerun tuners; assign a new IP address and hostname for this application, and define it as a secondary IP address on your Docker host's primary interface.
 
 For configuration, see the example docker-compose.yml. Set environment variables and secrets as defined here, then run "docker-compose up -d".
+
+As an alterantive, this can be run directly using environment variables. The mythtv user password cannot be setup this way, but you shouldn't be running ssh after initial setup anyway.
+
+Use -v options to map in the paths to your media. For my purposes, I've mapped a single folder into /dvr.
+~~~
+docker run -d --name mythtv \
+--network=host \
+-e DBNAME='mythtv' \
+-e DBSERVER='<Your mysql server name or ip>' \
+-e DBPASSWORD='<Password for Mythtv User>' \
+-v <Your dvr/media storage path>:/dvr \
+instantlinux/mythtv-backend:latest
+~~~
 
 Reach mythtv-setup in the usual way after starting sshd on port 2022; default password is mythtv:
 ~~~
@@ -31,6 +44,7 @@ Variable | Default | Description
 APACHE_LOG_DIR | /var/log/apache2 | Apache logs
 DBNAME | mythtv | Database name
 DBSERVER | db00 | Database server hostname
+DBPASSWORD |    | Database server password
 LANG | en_US.UTF-8 | 
 LANGUAGE | en_US.UTF-8 | 
 LOCALHOSTNAME | | Override if needed (see [config.xml](https://www.mythtv.org/wiki/Config.xml))

--- a/images/mythtv-backend/src/entrypoint.sh
+++ b/images/mythtv-backend/src/entrypoint.sh
@@ -12,8 +12,8 @@ if [ "$OSTYPE" == "opensuse" ]; then
 elif [ "$OSTYPE" == "ubuntu" ]; then
   if [[ $(cat /etc/timezone) != $TZ ]]; then
     echo $TZ > /etc/timezone
-    sed -i -e "s#;date.timezone.*#date.timezone = ${TZ}#g" /etc/php/7.0/apache2/php.ini
-    sed -i -e "s#;date.timezone.*#date.timezone = ${TZ}#g" /etc/php/7.0/cli/php.ini
+    sed -i -e "s#;date.timezone.*#date.timezone = ${TZ}#g" /etc/php/7.2/apache2/php.ini
+    sed -i -e "s#;date.timezone.*#date.timezone = ${TZ}#g" /etc/php/7.2/cli/php.ini
     dpkg-reconfigure -f noninteractive tzdata
   fi
   CONF_DIR=/etc/apache2/sites-available
@@ -55,6 +55,7 @@ mkdir -p /var/run/sshd
 
 for mod in deflate filter headers rewrite; do a2enmod $mod; done
 a2ensite mythweb mythweb-settings
+a2dissite 000-default-mythbuntu
 apache2ctl start
 
 for retry in $(seq 1 10); do


### PR DESCRIPTION
Updated entrypoint.sh and Dockerfile to prevent apache from wanting port 80. Makes this usable on boxes with another webserver running.
Upgraded to Ubuntu 18.04 Bionic
Added additional usage information to the readme describing usage without using compose/kubernetes/etc.