### PR TITLE
fix dovecot shebang

### DIFF
--- a/images/dovecot/entrypoint-dovecot.sh
+++ b/images/dovecot/entrypoint-dovecot.sh
@@ -1,4 +1,4 @@
-#/bin/sh -e
+#!/bin/sh -e
 
 if [ ! -f /etc/timezone ] && [ ! -z "$TZ" ]; then
   # At first startup, set timezone


### PR DESCRIPTION
It's missing a "!" which causes podman to give this error:
> standard_init_linux.go:211: exec user process caused "exec format error"