### PR TITLE
include libmyth-python in the mythtv-backend build

### DIFF
--- a/images/mythtv-backend/Dockerfile
+++ b/images/mythtv-backend/Dockerfile
@@ -37,8 +37,8 @@ RUN \
     apache2 curl iputils-ping less lsb-release mariadb-client net-tools \
     openssh-client openssh-server mythtv-backend=$MYTHTV_VERSION \
     mythtv-common=$MYTHTV_VERSION mythtv-transcode-utils=$MYTHTV_VERSION \
-    mythweb=$MYTHTV_VERSION php-mythtv psmisc sudo tzdata v4l-utils vim \
-    w3m x11-utils xauth xmltv xterm
+    mythweb=$MYTHTV_VERSION libmyth-python php-mythtv psmisc sudo tzdata \
+    v4l-utils vim w3m x11-utils xauth xmltv xterm
 
 COPY src/ /root/
 


### PR DESCRIPTION
include libmyth-python in the mythtv-backend build so that metadata jobs work.  without it, looks like this

```
$ /usr/share/mythtv/metadata/Television/ttvdb.py -t

The modules tvdb_api.py (v2.0 or greater).
They should have been installed along with the MythTV python bindings.
Error:(No module named 'MythTV')
```