### PR TITLE
[images/spamassassin] Install missing gpg and run sa-update on container start

### DIFF
--- a/images/spamassassin/Dockerfile
+++ b/images/spamassassin/Dockerfile
@@ -23,7 +23,7 @@ ARG SPAMD_UID=2022
 RUN apt-get -yq update && \
     apt-get -y --no-install-recommends install \
      ca-certificates cron curl gcc libc6-dev libdbd-mysql-perl \
-     libmail-dkim-perl libnet-ident-perl make pyzor razor \
+     libmail-dkim-perl libnet-ident-perl make pyzor razor gpg \
      spamassassin=$SPAMD_VERSION && \
      usermod --uid $SPAMD_UID $USERNAME && \
      mv /etc/mail/spamassassin/local.cf /etc/mail/spamassassin/local.cf-dist && \

--- a/images/spamassassin/entrypoint.sh
+++ b/images/spamassassin/entrypoint.sh
@@ -3,6 +3,8 @@ echo "$CRON_MINUTE $CRON_HOUR * * *   root   sa-update &&\
   kill -HUP \`cat /var/run/spamd.pid\`" > /etc/cron.d/sa-update
 cron
 
+/usr/bin/sa-update
+
 mkdir -p /var/run/dcc
 /var/dcc/libexec/dccifd -tREP,20 -tCMN,5, -llog -wwhiteclnt -Uuserdirs \
   -SHELO -Smail_host -SSender -SList-ID


### PR DESCRIPTION
2 Changes in this PR:
* sa-update is complaining about missing gpg and runs only with `--no-gpg` (which is not really an option). `/usr/bin/gpgv` shipped with Debian doesn-t work as replacement.
* Run `sa-update` on container start to not have to wait the next cron cycle to get an inital copy