### PR TITLE
[images/spamassassin] Enable DCC by default

### DIFF
--- a/images/spamassassin/Dockerfile
+++ b/images/spamassassin/Dockerfile
@@ -40,7 +40,10 @@ RUN apt-get -yq update && \
     sed -i 's/DCCIFD_ENABLE=off/DCCIFD_ENABLE=on/' /var/dcc/dcc_conf && \
     apt-get purge -yq binutils cpp-8 libc6-dev libgcc-8-dev \
      linux-libc-dev make && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/log/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/log/* && \
+\
+# Uncomment DCC loading to enable it
+    sed -i '/^#\s*loadplugin .\+::DCC/s/^#\s*//g' /etc/spamassassin/v310.pre
 
 COPY entrypoint.sh /root/
 VOLUME ["/var/lib/spamassassin", "/var/log"]


### PR DESCRIPTION
DCC plugin is installed but not loaded (`loadplugin` is commented in v310.pre). 

Debian is not using DCC by default, since it's not open-source. But since we ar egoing through the hassle of installing it, we might also enable it.