### PR TITLE
Add nut sdorder configuration 

### DIFF
--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -16,6 +16,7 @@ ENV API_USER=upsmon \
     NAME=ups \
     POLLINTERVAL= \
     PORT=auto \
+    SDORDER= \
     SECRET=nut-upsd-password \
     SERIAL= \
     SERVER=master \

--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG NUT_VERSION=2.7.4-r8
+ARG NUT_VERSION=2.7.4-r10
 ENV API_USER=upsmon \
     DESCRIPTION=UPS \
     DRIVER=usbhid-ups \

--- a/images/nut-upsd/Dockerfile.arm32
+++ b/images/nut-upsd/Dockerfile.arm32
@@ -16,6 +16,7 @@ ENV API_USER=upsmon \
     NAME=ups \
     POLLINTERVAL= \
     PORT=auto \
+    SDORDER= \
     SECRET=nut-upsd-password \
     SERIAL= \
     SERVER=master \

--- a/images/nut-upsd/Dockerfile.arm32
+++ b/images/nut-upsd/Dockerfile.arm32
@@ -8,7 +8,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG NUT_VERSION=2.7.4-r6
+ARG NUT_VERSION=2.7.4-r10
 ENV API_USER=upsmon \
     DESCRIPTION=UPS \
     DRIVER=usbhid-ups \

--- a/images/nut-upsd/Dockerfile.arm64
+++ b/images/nut-upsd/Dockerfile.arm64
@@ -16,6 +16,7 @@ ENV API_USER=upsmon \
     NAME=ups \
     POLLINTERVAL= \
     PORT=auto \
+    SDORDER= \
     SECRET=nut-upsd-password \
     SERIAL= \
     SERVER=master \

--- a/images/nut-upsd/Dockerfile.arm64
+++ b/images/nut-upsd/Dockerfile.arm64
@@ -8,7 +8,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG NUT_VERSION=2.7.4-r6
+ARG NUT_VERSION=2.7.4-r10
 ENV API_USER=upsmon \
     DESCRIPTION=UPS \
     DRIVER=usbhid-ups \

--- a/images/nut-upsd/README.md
+++ b/images/nut-upsd/README.md
@@ -45,6 +45,7 @@ GROUP | nut | local group
 NAME | ups | user-assigned config name
 POLLINTERVAL | | Poll Interval for ups.conf
 PORT | auto | device port (e.g. /dev/ttyUSB0) on host
+SDORDER | | UPS shutdown sequence, set to -1 to disable shutdown
 SECRET | nut-upsd-password | secret to use for API user
 SERIAL | | hardware serial number of UPS
 SERVER | master | master or slave priority for scripts
@@ -65,8 +66,8 @@ Device: ID 051d:0002 American Power Conversion Uninterruptible Power Supply
   idProduct          0x0002 Uninterruptible Power Supply
   bcdDevice            0.90
   iManufacturer           1 American Power Conversion
-  iProduct                2 Back-UPS RS 1500G FW:865.L6 .D USB FW:L6 
-  iSerial                 3 4B1624P26350  
+  iProduct                2 Back-UPS RS 1500G FW:865.L6 .D USB FW:L6
+  iSerial                 3 4B1624P26350
 ```
 
 If you require udev rules to set permissions, configure your host prior to running the container. For example:

--- a/images/nut-upsd/entrypoint.sh
+++ b/images/nut-upsd/entrypoint.sh
@@ -22,6 +22,9 @@ EOF
     if [ ! -z "$VENDORID" ]; then
       echo "        vendorid = $VENDORID" >> /etc/nut/ups.conf
     fi
+    if [ ! -z "$SDORDER" ]; then
+      echo "        sdorder = $SDORDER" >> /etc/nut/ups.conf
+    fi
   fi
   if [ -e /etc/nut/local/upsd.conf ]; then
     cp /etc/nut/local/upsd.conf /etc/nut/upsd.conf


### PR DESCRIPTION
This allows configuring nut driver's sdorder parameter. This is mainly useful when set to -1 as nut will not issue shutdown order to the UPS in low battery condition.
The container can't shutdown the host system anyway without further tweaks so shutting down the UPS seems unnecessary especially when using UPS that reports Low Battery very early.