### PR TITLE
Realm should be upper-case.

### DIFF
--- a/images/samba-dc/entrypoint.sh
+++ b/images/samba-dc/entrypoint.sh
@@ -5,7 +5,7 @@ if [ -z "$NETBIOS_NAME" ]; then
 else
   NETBIOS_NAME=$(echo $NETBIOS_NAME | tr [a-z] [A-Z])
 fi
-REALM=$(echo "$REALM" | tr [A-Z] [a-z])
+REALM=$(echo "$REALM" | tr [a-z] [A-Z])
 
 if [ ! -f /etc/timezone ] && [ ! -z "$TZ" ]; then
   echo 'Set timezone'


### PR DESCRIPTION
As written in https://wiki.samba.org/index.php/Setting_up_Samba_as_an_Active_Directory_Domain_Controller. The "REALM"-Property is

"Kerberos realm. The uppercase version of the AD DNS domain. For example: SAMDOM.EXAMPLE.COM."