### PR TITLE
Fix NUT Issues 74, 75: Allow forgoing Docker secrets and fix permissions of custom configs

### DIFF
--- a/images/nut-upsd/entrypoint.sh
+++ b/images/nut-upsd/entrypoint.sh
@@ -6,9 +6,15 @@ else
   API_PASSWORD="$SECRET"
 fi
 
+cp_local_conf() {
+  cp "$1" "$2"
+  chown root:nut "$2"
+  chmod 0640 "$2"
+}
+
 if [ ! -e /etc/nut/.setup ]; then
   if [ -e /etc/nut/local/ups.conf ]; then
-    cp /etc/nut/local/ups.conf /etc/nut/ups.conf
+    cp_local_conf /etc/nut/local/ups.conf /etc/nut/ups.conf
   else
     if [ -z "$SERIAL" ]; then
       echo "** This container may not work without setting for SERIAL **"
@@ -31,14 +37,14 @@ EOF
     fi
   fi
   if [ -e /etc/nut/local/upsd.conf ]; then
-    cp /etc/nut/local/upsd.conf /etc/nut/upsd.conf
+    cp_local_conf /etc/nut/local/upsd.conf /etc/nut/upsd.conf
   else
     cat <<EOF >>/etc/nut/upsd.conf
 LISTEN 0.0.0.0
 EOF
   fi
   if [ -e /etc/nut/local/upsd.users ]; then
-    cp /etc/nut/local/upsd.users /etc/nut/upsd.users
+    cp_local_conf /etc/nut/local/upsd.users /etc/nut/upsd.users
   else
     cat <<EOF >>/etc/nut/upsd.users
 [$API_USER]
@@ -47,7 +53,7 @@ EOF
 EOF
   fi
   if [ -e /etc/nut/local/upsmon.conf ]; then
-    cp /etc/nut/local/upsmon.conf /etc/nut/upsmon.conf
+    cp_local_conf /etc/nut/local/upsmon.conf /etc/nut/upsmon.conf
   else
     cat <<EOF >>/etc/nut/upsmon.conf
 MONITOR $NAME@localhost 1 $API_USER $API_PASSWORD $SERVER

--- a/images/nut-upsd/entrypoint.sh
+++ b/images/nut-upsd/entrypoint.sh
@@ -1,6 +1,10 @@
 #! /bin/sh -e
 
-API_PASSWORD=$(cat /run/secrets/$SECRET)
+if [ -r "/run/secrets/$SECRET" ]; then
+  API_PASSWORD=$(cat /run/secrets/$SECRET)
+else
+  API_PASSWORD="$SECRET"
+fi
 
 if [ ! -e /etc/nut/.setup ]; then
   if [ -e /etc/nut/local/ups.conf ]; then


### PR DESCRIPTION
Fixes issue #74 by checking to ensure that `"/run/secrets/$SECRET"` is readable before attempting to do so; if it isn't, then assume that someone (unwisely) put the actual secret in the `SECRET` environment variable. It's possible that they didn't: they might be using custom configuration files. If this is the case, no-harm is done with this assumption.

Fixes issue #75 by explicitly setting each copied file's owner, group, and permissions to the same as the original file being replaced. The original issue is caused because `entrypoint.sh` is run by `root`, causing the copied `upsd.users` file to be owned by `root:root`; this isn't readable by upsd when it drops permissions to run as the `nut` user.