### PR TITLE
Make destination server configurable on ddclient docker entrypoint

### DIFF
--- a/images/ddclient/entrypoint.sh
+++ b/images/ddclient/entrypoint.sh
@@ -15,7 +15,7 @@ use=web
 web=$IPLOOKUP_URI
 ssl=yes
 
-server=members.easydns.com, protocol=$SERVICE_TYPE, login=$USER_LOGIN, password=$USER_PASSWORD $HOST
+server=$SERVER, protocol=$SERVICE_TYPE, login=$USER_LOGIN, password=$USER_PASSWORD $HOST
 EOF
 fi
 chown ddclient.ddclient /etc/ddclient/ddclient.conf


### PR DESCRIPTION
Currently the docker entrypoint for **ddclient** image has the server hardcoded.

With this commit we can successfully use the env variable to modify the destination server.

I tested it on a k8s cluster (installing it with helm), injecting the new entrypoint as a volume to replace the one existing in the image, but would like to share the solution for the repository.