### PR TITLE
samba-dc actually supports DNS_FORWARDER

### DIFF
--- a/images/samba-dc/Dockerfile
+++ b/images/samba-dc/Dockerfile
@@ -29,8 +29,9 @@ ARG SAMBA_VERSION=4.16.8-r0
 COPY *.conf.j2 /root/
 COPY entrypoint.sh /usr/local/bin/
 RUN apk add --update --no-cache krb5 ldb-tools samba-dc=$SAMBA_VERSION samba-winbind-clients=$SAMBA_VERSION tdb \
-      bind bind-libs bind-tools libcrypto1.1 libxml2 tzdata py3-pip && \
+      bind bind-libs bind-tools libcrypto1.1 libxml2 tzdata py3-setuptools py3-pip && \
     pip install j2cli && \
+    apk del py3-pip && \
     chmod 0755 /usr/local/bin/entrypoint.sh
 
 VOLUME /etc/samba /var/lib/samba

--- a/images/samba-dc/Dockerfile
+++ b/images/samba-dc/Dockerfile
@@ -29,7 +29,8 @@ ARG SAMBA_VERSION=4.16.8-r0
 COPY *.conf.j2 /root/
 COPY entrypoint.sh /usr/local/bin/
 RUN apk add --update --no-cache krb5 ldb-tools samba-dc=$SAMBA_VERSION samba-winbind-clients=$SAMBA_VERSION tdb \
-      bind bind-libs bind-tools libcrypto1.1 libxml2 tzdata && \
+      bind bind-libs bind-tools libcrypto1.1 libxml2 tzdata py3-pip && \
+    pip install j2cli && \
     chmod 0755 /usr/local/bin/entrypoint.sh
 
 VOLUME /etc/samba /var/lib/samba

--- a/images/samba-dc/entrypoint.sh
+++ b/images/samba-dc/entrypoint.sh
@@ -45,19 +45,7 @@ fi
 mkdir -p -m 700 /etc/samba/conf.d
 for file in /etc/samba/smb.conf /etc/samba/conf.d/netlogon.conf \
       /etc/samba/conf.d/sysvol.conf; do
-  sed -e "s:{{ ALLOW_DNS_UPDATES }}:$ALLOW_DNS_UPDATES:" \
-      -e "s:{{ BIND_INTERFACES_ONLY }}:$BIND_INTERFACES_ONLY:" \
-      -e "s:{{ DNS_FORWARDER }}:$DNS_FORWARDER:" \
-      -e "s:{{ DOMAIN_LOGONS }}:$DOMAIN_LOGONS:" \
-      -e "s:{{ DOMAIN_MASTER }}:$DOMAIN_MASTER:" \
-      -e "s+{{ INTERFACES }}+$INTERFACES+" \
-      -e "s:{{ LOG_LEVEL }}:$LOG_LEVEL:" \
-      -e "s:{{ NETBIOS_NAME }}:$NETBIOS_NAME:" \
-      -e "s:{{ REALM }}:$REALM:" \
-      -e "s:{{ SERVER_STRING }}:$SERVER_STRING:" \
-      -e "s:{{ WINBIND_USE_DEFAULT_DOMAIN }}:$WINBIND_USE_DEFAULT_DOMAIN:" \
-      -e "s:{{ WORKGROUP }}:$WORKGROUP:" \
-      /root/$(basename $file).j2 > $file
+  j2 /root/$(basename $file).j2 -o $file
 done
 for file in $(ls -A /etc/samba/conf.d/*.conf); do
   echo "include = $file" >> /etc/samba/smb.conf

--- a/images/samba-dc/smb.conf.j2
+++ b/images/samba-dc/smb.conf.j2
@@ -16,6 +16,4 @@
 	log level = {{ LOG_LEVEL }}
 	winbind refresh tickets = Yes
 	winbind use default domain = {{ WINBIND_USE_DEFAULT_DOMAIN }}
-{% if DNS_FORWARDER %}
-    dns forwarder = {{ DNS_FORWARDER }}
-{%  endif %}
+{% if DNS_FORWARDER %}	dns forwarder = {{ DNS_FORWARDER }}{%  endif %}

--- a/images/samba-dc/smb.conf.j2
+++ b/images/samba-dc/smb.conf.j2
@@ -16,4 +16,4 @@
 	log level = {{ LOG_LEVEL }}
 	winbind refresh tickets = Yes
 	winbind use default domain = {{ WINBIND_USE_DEFAULT_DOMAIN }}
-{% if DNS_FORWARDER %}	dns forwarder = {{ DNS_FORWARDER }}{%  endif %}
+{% if DNS_FORWARDER is defined and DNS_FORWARDER %}	dns forwarder = {{ DNS_FORWARDER }}{%  endif %}


### PR DESCRIPTION
This PR addresses issue #44 and enhances PR #96.

PR #96 introduces the DNS_FORWARDER variables but samba-dc doesn't actually use the jinja2 templating despite the .j2 file extension. This PR moves from using sed to j2cli for templating and completes support for DNS_FORWARDER.