### PR TITLE
Issue #119 - fix NAME parameter in nut-upsd

### DIFF
--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -22,7 +22,7 @@ ENV API_USER=upsmon \
     SERVER=master \
     USER=nut \
     VENDORID=
-HEALTHCHECK CMD upsc ups@localhost:3493 2>&1|grep -q stale && exit 1 || true
+HEALTHCHECK CMD upsc $$NAME@localhost:3493 2>&1|grep -q stale && exit 1 || true
 
 RUN apk add --update nut=$NUT_VERSION \
       libcrypto1.1 libssl1.1 libusb musl net-snmp-libs


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Fix the default healthcheck for nut-upsd image.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
To address bug report from @Alarez777:
> The healthcheck does not work in the nut-upsd container when the NAME environment variable is changed. It seems that the problem is in docker-tools/images/nut-upsd/dockerfile in this line because the $NAME variable is not considered:
```
HEALTHCHECK CMD upsc ups@localhost:3493 2>&1|grep -q stale && exit 1 || true
```
## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local test: built image, launched with `$NAME` unset, then with `$NAME` set to a non-default value.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
