### PR TITLE
Issue #86 remove VIP upon stop - haproxy-keepalived

### DIFF
--- a/images/haproxy-keepalived/Dockerfile
+++ b/images/haproxy-keepalived/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.8.1-alpine
+FROM haproxy:2.8.2-alpine
 MAINTAINER Rich Braun "docker@instantlinux.net"
 ARG BUILD_DATE
 ARG VCS_REF

--- a/images/haproxy-keepalived/docker-compose.yml
+++ b/images/haproxy-keepalived/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       KEEPALIVE_CONFIG_ID: ${KEEPALIVED_CONFIG_ID:-main}
       TZ: ${TZ:-UTC}
+    stop_signal: SIGTERM
     volumes:
     - ${ADMIN_PATH:-/opt}/haproxy/etc:/usr/local/etc/haproxy.d:ro
     - ${ADMIN_PATH:-/opt}/keepalived/etc/keepalived.conf:/etc/keepalived/keepalived.conf:ro

--- a/images/haproxy-keepalived/entrypoint.sh
+++ b/images/haproxy-keepalived/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/sh -e
 
+function graceful_stop() {
+    echo "Received SIGTERM"
+    kill -SIGTERM $(cat /run/keepalived/*.pid)
+    exit 0
+}
+
 if [ -s /run/secrets/$STATS_SECRET ]; then
   STATS_PASSWORD=$(cat /run/secrets/$STATS_SECRET)
 else
@@ -60,6 +66,9 @@ rm -f /run/rsyslogd.pid && rsyslogd
 if ! keepalived -i $KEEPALIVE_CONFIG_ID; then
   echo keepalived did not start, needs working /etc/keepalived/keepalived.conf
 fi
+trap graceful_stop SIGTERM
+
 sleep 10
 haproxy -f $HAPROXY_PATH/haproxy.cfg $CMD_OPTS || true
-tail +1 -f /var/log/messages
+tail +1 -f /var/log/messages &
+wait

--- a/images/haproxy-keepalived/helm/Chart.yaml
+++ b/images/haproxy-keepalived/helm/Chart.yaml
@@ -7,8 +7,8 @@ sources:
 - https://github.com/haproxy/haproxy
 - https://github.com/acassen/keepalived
 type: application
-version: 0.1.11
-appVersion: "2.8.1-alpine-2.2.8-r0"
+version: 0.1.12
+appVersion: "2.8.2-alpine-2.2.8-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Catch the SIGTERM signal to shut down keepalived properly upon container termination.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
To address bug report from @breezytm:
> keepalive is failing to remove the network from the master causing the load balancing to fail during a failover. I reached out to keepalived team and here's what they said is the root cause. https://github.com/acassen/keepalived/issues/2201#issuecomment-1251444660
## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local test: built image, launched and invoked `docker stop keepalived_app_1`.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
