### PR TITLE
Issue #86 set stopsignal in haproxy-keepalived image

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary of Changes
+
+<!-- (required) Describe the effects of your pull request in detail. If multiple
+changes are involved, a bulleted list is often useful. -->
+
+## Why is this change being made?
+
+<!-- (required) Describe the reasoning and background context for your
+change. Include link(s) to relevant issue(s). -->
+
+## How was this tested? How can the reviewer verify your testing?
+
+<!-- (required) Describe the steps you used to reproduce the problem this change
+fixes, and how to test your change. Provide explicit, repeatable instructions
+the reviewer can follow to verify your testing. -->
+
+## Completion checklist
+
+- [ ] The pull request is linked to all related issues
+- [ ] This change has unit test coverage
+- [ ] Documentation has been updated
+- [ ] Dependencies have been updated and verified

--- a/images/haproxy-keepalived/Dockerfile
+++ b/images/haproxy-keepalived/Dockerfile
@@ -19,6 +19,7 @@ ENV KEEPALIVE_CONFIG_ID=main \
     TZ=UTC
 
 USER root
+STOPSIGNAL SIGTERM
 RUN apk add --no-cache --update \
       keepalived=$KEEPALIVED_VERSION rsyslog && \
     getent passwd haproxy || adduser -S -u 99 haproxy && \


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Define the `STOPSIGNAL` in haproxy-keepalived image.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Kubernetes must be told explicitly what signal to use; by default the stopsignal is `SIGUSR1` and it should be `SIGTERM`.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local test: built image, launched under helm, then `helm delete haproxy-keepalived`. Can now see the log message `Received SIGTERM` prior to container shutdown. (Still not working fully, though - the VIP isn't getting torn down despite the script apparently reaching the correct function.)

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
