### PR TITLE
Issue #86 wait for termination in haproxy-keepalived

### DIFF
--- a/images/haproxy-keepalived/entrypoint.sh
+++ b/images/haproxy-keepalived/entrypoint.sh
@@ -3,7 +3,7 @@
 function graceful_stop() {
     echo "Received SIGTERM"
     kill -SIGTERM $(cat /run/keepalived/*.pid)
-    exit 0
+    sleep 1; exit 0
 }
 
 if [ -s /run/secrets/$STATS_SECRET ]; then


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Add a 1-second delay to the graceful-stop function in haproxy-keepalived.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Apparently the container was shutting down so quickly under k8s that keepalived didn't have time to remove the VIP.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing using `helm delete haproxy-keepalived`.

## Completion checklist

- [x] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [ ] Documentation has been updated
- [x] Dependencies have been updated and verified
