### PR TITLE
Issue #79 replace lograte script in rsyslogd; adjust data-sync

### DIFF
--- a/images/data-sync/helm/Chart.yaml
+++ b/images/data-sync/helm/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/instantlinux/docker-tools
 sources:
 - https://github.com/instantlinux/docker-tools
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "2.53.3-4.14.1-r1"
 dependencies:
 - name: chartlib

--- a/images/data-sync/helm/values.yaml
+++ b/images/data-sync/helm/values.yaml
@@ -123,8 +123,10 @@ configmap:
       ignore = Path data-sync/gitlab/logs/sshd/current
       ignore = Path data-sync/jira/home/analytics-logs
       ignore = Path data-sync/jira/home/log/atlassian-jira.log
+      ignore = Path data-sync/jira/home/log/atlassian-jira-ipd-monitoring.log
       ignore = Path data-sync/jira/home/log/atlassian-jira-outgoing-mail.log
       ignore = Path data-sync/jira/home/log/atlassian-jira-perf.log
+      ignore = Path data-sync/jira/home/log/automation-jira-performance.csv
       ignore = Path data-sync/jira/home/monitor/ConnectionPoolGraph.rrd4j
       ignore = Path data-sync/jira/home/monitor/DatabaseReadWritesGraph.rrd4j
       ignore = Path data-sync/jira/home/plugins/.osgi-plugins/felix/felix-cache

--- a/images/rsyslogd/Dockerfile
+++ b/images/rsyslogd/Dockerfile
@@ -16,6 +16,8 @@ RUN apk add --update gzip logrotate rsyslog=$RSYSLOG_VERSION \
 VOLUME /var/log /etc/logrotate.d /etc/rsyslog.d
 EXPOSE 514 514/udp
 COPY logrotate.conf /etc/logrotate.conf
+COPY rsyslog-rotate /etc/logrotate.d/rsyslog
+
 RUN chmod 644 /etc/logrotate.conf
 
 ADD entrypoint.sh /root/

--- a/images/rsyslogd/rsyslog-rotate
+++ b/images/rsyslogd/rsyslog-rotate
@@ -1,0 +1,19 @@
+/var/log/messages
+/var/log/auth.log
+/var/log/cron.log
+/var/log/kern.log
+/var/log/mail.log
+{
+    compress
+    dateext
+    maxage 365
+    rotate 45
+    missingok
+    notifempty
+    size +4096k
+    create 640 root root
+    sharedscripts
+    postrotate
+        /usr/bin/killall -HUP rsyslogd
+    endscript
+}


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Add a corrected logrotate config to rsyslog image, and adjust the data-sync helm chart to handle latest jira logs.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
As noted by @pjacak, the alpine distro's rsyslog package invokes an incorrect logrotate command. Also, latest version of jira has a couple of new logs that interfere with `unison` in the data-sync image.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [ ] Documentation has been updated
- [ ] Dependencies have been updated and verified
