### PR TITLE
SYS-607 update for apt keys, drive-health and restic

### DIFF
--- a/ansible/roles/docker_node/defaults/main.yml
+++ b/ansible/roles/docker_node/defaults/main.yml
@@ -10,7 +10,7 @@ docker_defaults:
     key: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
     package_name: docker-ce
     package_ver: 5:23.0.1-1~ubuntu.22.04~jammy
-    repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
+    repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
     url: https://download.docker.com/linux/ubuntu/gpg
   certs:
     ca_root: ca-root.pem

--- a/ansible/roles/docker_node/tasks/repos.yml
+++ b/ansible/roles/docker_node/tasks/repos.yml
@@ -6,17 +6,11 @@
   with_items: "{{ ubuntu_repos }}"
 
 - name: Docker repo key
-  # TODO - apt-key is deprecated since 2020 or so
-  apt_key:
-    id: "{{ docker.apt_repo.key }}"
+  get_url:
     url: "{{ docker.apt_repo.url }}"
-    state: present
+    dest: /etc/apt/keyrings/docker.asc
 
 - name: Docker repo
   apt_repository:
     filename: docker
     repo: "{{ docker.apt_repo.repo }}"
-  # TODO - this fails with
-  #  Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see
-  #   the DEPRECATION section in apt-key(8) for details.
-  ignore_errors: True

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -13,7 +13,7 @@ k8s_defaults:
   admin_config: /etc/kubernetes/admin.conf
   apt_repo:
     # TODO use {{ ansible_distribution_release }}
-    repo: deb http://apt.kubernetes.io/ kubernetes-xenial main
+    repo: deb [signed-by=/etc/apt/keyrings/kubernetes.asc] http://apt.kubernetes.io/ kubernetes-xenial main
     url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
   kubeadm_opts: ''
   local_vols: /var/lib/docker/k8s-volumes
@@ -25,7 +25,7 @@ k8s_defaults:
     name: kubelet
     state: restarted
   service_network: 10.96.0.0/12
-  version: 1.25.3
+  version: 1.25.4
   cni_version: 1.1.1
 k8s_override: {}
 k8s: "{{ k8s_defaults | combine(k8s_override) }}"

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 - name: k8s repo key
-  apt_key:
+  get_url:
     url: "{{ k8s.apt_repo.url }}"
+    dest: /etc/apt/keyrings/kubernetes.asc
 
 - name: k8s repo
   apt_repository:

--- a/ansible/roles/monitoring_agent/files/plugins/check_drive_health.py
+++ b/ansible/roles/monitoring_agent/files/plugins/check_drive_health.py
@@ -49,7 +49,7 @@ import os
 import sys
 import yaml
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 STATUS_OK = 0
 STATUS_WARN = 1
@@ -198,7 +198,7 @@ def dot_get(_dict, path, default=None):
     for key in path.split('.'):
         try:
             _dict = _dict[key]
-        except KeyError:
+        except (KeyError, TypeError):
             return default
     return _dict
 

--- a/k8s/helm/restic/Chart.yaml
+++ b/k8s/helm/restic/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 version: 0.1.5
 # Remember to update restic==<ver> in values.yaml as releases are published;
 #  the values.yaml file is not able to reference .Chart.appVersion
-appVersion: "0.15.2-r1"
+appVersion: "0.15.2-r2"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/restic/values.yaml
+++ b/k8s/helm/restic/values.yaml
@@ -7,7 +7,7 @@ deployment:
   args:
   - -c
   - >
-    apk add --update restic==0.15.2-r1 tzdata &&
+    apk add --update restic==0.15.2-r2 tzdata &&
     ln -s /usr/share/zoneinfo/$TZ /etc/localtime &&
     echo $TZ > /etc/timezone &&
     echo "if [ -r $HOME/.resticrc ]; then . $HOME/.resticrc; fi" \


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Minor housecleaning:
* Eliminate deprecated references to `apt-key` ansible module
* Update restic helm chart
* Catch unexpected exception in `check_drive_health` nagios plugin

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
To bring nagios, ansible, restic up to current standards.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Manual verification

## Completion checklist

- [x] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [ ] Documentation has been updated
- [x] Dependencies have been updated and verified
