### PR TITLE
SYS-607 update gitlab helm chart to 16.3.3; tweak ansible for virtualbox

### DIFF
--- a/ansible/roles/fileserver/tasks/virtualbox.yml
+++ b/ansible/roles/fileserver/tasks/virtualbox.yml
@@ -1,14 +1,17 @@
 ---
 
 - name: Virtualbox repo key
-  apt_key:
+  get_url:
     url: "{{ item }}"
+    dest: /etc/apt/keyrings/{{ item | basename }}
   with_items:
   - "{{ virtualbox.apt_repo.key_urls }}"
 
 - name: Virtualbox repository
   apt_repository:
-    repo: deb [arch=amd64] {{ virtualbox.apt_repo.url }} {{ ansible_distribution_release }} contrib
+    repo: >
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/oracle_vbox_2016.asc]
+      {{ virtualbox.apt_repo.url }} {{ ansible_distribution_release }} contrib
     filename: virtualbox
 
 - name: Virtualbox package

--- a/k8s/helm/gitlab/Chart.yaml
+++ b/k8s/helm/gitlab/Chart.yaml
@@ -7,8 +7,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://gitlab.com/gitlab-org/gitlab
 type: application
-version: 0.1.6
-appVersion: "15.8.0-ce.0"
+version: 0.1.7
+appVersion: "16.3.3-ce.0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/gitlab/templates/configmap.yaml
+++ b/k8s/helm/gitlab/templates/configmap.yaml
@@ -7,7 +7,6 @@ metadata:
 data:
   gitlab.rb: |
     external_url 'http://{{ .Values.tlsHostname }}'
-    gitaly['logging_level'] = '{{ .Values.gitaly.logging_level }}'
     gitlab_rails['backup_keep_time'] = 2592000
     gitlab_rails['db_adapter'] = 'postgresql'
     gitlab_rails['db_encoding'] = 'utf8'

--- a/k8s/helm/gitlab/values.yaml
+++ b/k8s/helm/gitlab/values.yaml
@@ -1,6 +1,4 @@
 # Default values for gitlab.
-gitaly:
-  logging_level: warn
 gitlab_shell:
   log_level: WARN
 nginx:


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Housekeeping update:
* Gitlab helm chart now supports version `16.3.3`, which retired the `logging_level` setting for gitaly. (There is still 20x as much log output from gitlab container as there should be -- almost none of it useful -- and nobody at GitLab wants to tackle this problem after years of complaints.)
* Replaced deprecated `apt_key` resource with `get_url` in ansible fileserver role: I dunno why the folks at ansible didn't just fix apt_key to do the right thing for debian-based distros

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

Support latest versions to comply with current security best practices.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Brought up gitlab, verified functionality; cleared out virtualbox repo settings and confirmed the new resource definition works properly.

## Completion checklist

- [x] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [ ] Documentation has been updated
- [x] Dependencies have been updated and verified
