### PR TITLE
Allow API_USER to have access to commands

### DIFF
--- a/images/nut-upsd/entrypoint.sh
+++ b/images/nut-upsd/entrypoint.sh
@@ -44,6 +44,7 @@ EOF
 [$API_USER]
         password = $API_PASSWORD
         upsmon $SERVER
+        instcmds = ALL
 EOF
   fi
   if [ -e /etc/nut/local/upsmon.conf ]; then


### PR DESCRIPTION
Without this line added, the API_USER account cannot do things like enable/disable the beeper

## Summary of Changes

I added in a line to the entrypoint.sh that allows the API_USER to issue commands. This was the workaround fix I made on for my own uses. The sample uspd.users file mentions how `instcmds` works [here](https://networkupstools.org/docs/man/upsd.users.html)

## Why is this change being made?

This is needed in order to have Home Assistant do commands such as enable/disable the beeper.

## How was this tested? How can the reviewer verify your testing?

Without this change, I got an access denied message when trying to run commands. I replaced the original entrypoint.sh with this change and created a new docker image on top of the instantlinux/nut-upsd and supplanted my new entrypoint.sh. I was able to issue commands after that. 

## Completion checklist

- [ ] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [ ] Documentation has been updated
- [ ] Dependencies have been updated and verified
