### PR TITLE
Issue #119 fix nut-upsd healthcheck, update SSL libs

### DIFF
--- a/images/git-dump/Dockerfile
+++ b/images/git-dump/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.19
 MAINTAINER Rich Braun "docker@instantlinux.net"
 ARG BUILD_DATE
 ARG VCS_REF
@@ -18,7 +18,7 @@ ENV API_TOKEN_SECRET= \
     USERNAME=git-dump \
     TZ=UTC
 
-ARG GIT_VERSION=2.40.1-r0
+ARG GIT_VERSION=2.43.0-r0
 ARG GROUP=care
 ARG GID=505
 ARG UID=212

--- a/images/git-dump/helm/Chart.yaml
+++ b/images/git-dump/helm/Chart.yaml
@@ -5,8 +5,8 @@ home: https://github.com/instantlinux/docker-tools
 sources:
 - https://github.com/instantlinux/docker-tools
 type: application
-version: 0.1.11
-appVersion: "2.40.1-r0"
+version: 0.1.12
+appVersion: "2.43.0-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/git-pull/Dockerfile
+++ b/images/git-pull/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.19
 MAINTAINER Rich Braun <docker@instantlinux.net>
 ARG BUILD_DATE
 ARG VCS_REF
@@ -8,7 +8,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG GIT_VERSION=2.40.1-r0
+ARG GIT_VERSION=2.43.0-r0
 ENV DEST=. \
     GIT_COMMIT=master \
     GIT_HOST=github.com \

--- a/images/git-pull/helm/Chart.yaml
+++ b/images/git-pull/helm/Chart.yaml
@@ -5,8 +5,8 @@ home: https://github.com/instantlinux/docker-tools
 sources:
 - https://github.com/instantlinux/docker-tools
 type: application
-version: 0.1.9
-appVersion: "2.40.1-r0"
+version: 0.1.10
+appVersion: "2.43.0-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.19
 MAINTAINER Rich Braun "docker@instantlinux.net"
 ARG BUILD_DATE
 ARG VCS_REF
@@ -7,7 +7,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.name=nut-upsd \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
-ARG NUT_VERSION=2.8.0-r4
+ARG NUT_VERSION=2.8.1-r0
 ENV API_USER=upsmon \
     API_PASSWORD= \
     DESCRIPTION=UPS \
@@ -25,7 +25,7 @@ ENV API_USER=upsmon \
 HEALTHCHECK CMD upsc $NAME@localhost:3493 2>&1|grep -q stale && exit 1 || true
 
 RUN apk add --update nut=$NUT_VERSION \
-      libcrypto1.1 libssl1.1 libusb musl net-snmp-libs
+      libcrypto3 libssl3 libusb musl net-snmp-libs
 
 EXPOSE 3493
 COPY entrypoint.sh /usr/local/bin/

--- a/images/nut-upsd/helm/Chart.yaml
+++ b/images/nut-upsd/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/networkupstools/nut
 type: application
-version: 0.1.4
-appVersion: "2.8.0-r4"
+version: 0.1.5
+appVersion: "2.8.1-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/nut-upsd/helm/values.yaml
+++ b/images/nut-upsd/helm/values.yaml
@@ -6,6 +6,13 @@ deployment:
     privileged: true
   strategy:
     type: Recreate
+livenessProbe:
+  exec:
+    command:
+    - /bin/sh
+    - -c
+    - 'upsc ups@localhost:3493 2>&1|grep -q stale && exit 1 || true'
+  periodSeconds: 30
 volumeMounts:
 # TODO make this work with pod security policies instead of securityContext
 # - name: usb
@@ -22,9 +29,11 @@ volumes:
     secretName: nut-upsd-password
 
 image:
-  repository: instantlinux/nut-upsd
+  # repository: instantlinux/nut-upsd
   pullPolicy: IfNotPresent
   # tag: default
+  repository: nexus.instantlinux.net/nut-upsd
+  tag: testing
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Followup to PR #140 - add `livenessProbe` to nut-upsd. Alpine 3.19 is now out, so this upgrades libssl and libcrypto dependencies from version 1.1 to 3.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
To make behavior consistent under kubernetes, to run same healthcheck as under docker-compose.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [ ] Documentation has been updated
- [x] Dependencies have been updated and verified
