### PR TITLE
Issue #67 nut-upsd healthcheck improvements, add MAXAGE variable

### DIFF
--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -13,6 +13,7 @@ ENV API_USER=upsmon \
     DESCRIPTION=UPS \
     DRIVER=usbhid-ups \
     GROUP=nut \
+    MAXAGE=15 \
     NAME=ups \
     POLLINTERVAL= \
     PORT=auto \
@@ -22,7 +23,8 @@ ENV API_USER=upsmon \
     SERVER=master \
     USER=nut \
     VENDORID=
-HEALTHCHECK CMD upsc $NAME@localhost:3493 2>&1|grep -q stale && exit 1 || true
+HEALTHCHECK CMD upsc $NAME@localhost:3493 2>&1|grep -q stale && \
+    kill -SIGTERM -1 || true
 
 RUN apk add --update nut=$NUT_VERSION \
       libcrypto3 libssl3 libusb musl net-snmp-libs

--- a/images/nut-upsd/README.md
+++ b/images/nut-upsd/README.md
@@ -17,7 +17,7 @@ This will expose TCP port 3493; to reach it with the standard Nagios plugin, set
 
 As a read-only service intended for monitoring, this container makes no attempt to lock down network security.
 
-Verified with the most-common type of UPS, the APC consumer-grade product; Tripp Lite models also (probably) work. Note that the usbhid-ups driver for APC requires you to provide the correct 12-digit hardware serial number. All other parameter defaults will work.
+Verified with the most-common type of UPS, the APC consumer-grade product; Tripp Lite models also (probably) work. CyberPower models need a MAXAGE parameter set longer than default (25). Note that the usbhid-ups driver for APC requires you to provide the correct 12-digit hardware serial number. All other parameter defaults will work.
 
 If you have a different model of UPS, contents of the files ups.conf, upsd.conf, upsmon.conf, and/or upsd.users can be overridden by mounting them to /etc/nut/local.
 
@@ -43,6 +43,7 @@ API_PASSWORD | | API password, if not using secret
 DESCRIPTION | UPS | user-assigned description
 DRIVER | usbhid-ups | driver (see [compatibility list](http://networkupstools.org/stable-hcl.html))
 GROUP | nut | local group
+MAXAGE | 15 | seconds before declaring driver non-responsive
 NAME | ups | user-assigned config name
 POLLINTERVAL | | Poll Interval for ups.conf
 PORT | auto | device port (e.g. /dev/ttyUSB0) on host

--- a/images/nut-upsd/entrypoint.sh
+++ b/images/nut-upsd/entrypoint.sh
@@ -30,6 +30,9 @@ EOF
       echo "        sdorder = $SDORDER" >> /etc/nut/ups.conf
     fi
   fi
+  if [ "$MAXAGE" -ne 15 ]; then
+      sed -i -e "s/^[# ]*MAXAGE [0-9]\+/MAXAGE $MAXAGE/" /etc/nut/upsd.conf
+  fi
   if [ -e /etc/nut/local/upsd.conf ]; then
     cp /etc/nut/local/upsd.conf /etc/nut/upsd.conf
   else

--- a/images/nut-upsd/helm/Chart.yaml
+++ b/images/nut-upsd/helm/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/networkupstools/nut
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "2.8.1-r0"
 dependencies:
 - name: chartlib

--- a/images/nut-upsd/helm/values.yaml
+++ b/images/nut-upsd/helm/values.yaml
@@ -1,6 +1,8 @@
 # Default values for nut-upsd.
 deployment:
   env:
+    driver: usbhid-ups
+    maxage: 15
     serial: mustbeset
   securityContext:
     privileged: true


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Adds the `MAXAGE` parameter (default 15 seconds) for configuring upsd.conf, and change behavior of HEALTHCHECK under docker-compose (now kills container upon failure).

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

CyberPower UPS units have long had trouble with stale-data causing the container to fail, as noted in discussion of issue #67.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

## Completion checklist

- [x] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [x] Documentation has been updated
- [ ] Dependencies have been updated and verified
