### PR TITLE
SYS-619 roll back weewx / haproxy-keepalived; update a few helm charts

### DIFF
--- a/images/dovecot/Dockerfile
+++ b/images/dovecot/Dockerfile
@@ -1,4 +1,4 @@
-FROM instantlinux/postfix:3.8.2-r0
+FROM instantlinux/postfix:3.8.3-r1
 
 MAINTAINER Rich Braun "docker@instantlinux.net"
 ARG BUILD_DATE
@@ -9,7 +9,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG DOVECOT_VERSION=2.3.20-r11
+ARG DOVECOT_VERSION=2.3.21-r17
 ARG MKCERT_SHA=24b6988d1709e71c24dcf94ffce5db93bd2e89dc5cbec1ac3c173de5274b68dd
 
 ENV LDAP_PASSWD_SECRET=ldap-ro-password \
@@ -21,7 +21,7 @@ RUN echo '@old http://dl-cdn.alpinelinux.org/alpine/v3.11/main' \
     apk add --no-cache dovecot=$DOVECOT_VERSION dovecot-ldap=$DOVECOT_VERSION \
       procmail@old && \
     rm /etc/ssl/dovecot/server.* && cd /usr/local/bin && \
-    wget -q https://raw.githubusercontent.com/dovecot/core/release-2.3.13/doc/mkcert.sh && \
+    wget -q https://raw.githubusercontent.com/dovecot/core/release-2.3.21/doc/mkcert.sh && \
     echo "$MKCERT_SHA  mkcert.sh" | sha256sum -c && \
     chmod 755 /usr/local/bin/mkcert.sh
     

--- a/images/dovecot/helm/Chart.yaml
+++ b/images/dovecot/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/vdukhovni/dovecot
 type: application
-version: 0.1.7
-appVersion: "2.3.20-r11"
+version: 0.1.8
+appVersion: "2.3.21-r17"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/haproxy-keepalived/Dockerfile
+++ b/images/haproxy-keepalived/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.9.1-alpine
+FROM haproxy:2.8.3-alpine
 MAINTAINER Rich Braun "docker@instantlinux.net"
 ARG BUILD_DATE
 ARG VCS_REF

--- a/images/haproxy-keepalived/helm/Chart.yaml
+++ b/images/haproxy-keepalived/helm/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 - https://github.com/acassen/keepalived
 type: application
 version: 0.1.14
-appVersion: "2.9.1-alpine-2.2.8-r0"
+appVersion: "2.8.3-alpine-2.2.8-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/mysqldump/helm/Chart.yaml
+++ b/images/mysqldump/helm/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/mariadb/server/tree/10.5/client
 type: application
-version: 0.1.8git 
+version: 0.1.8
 appVersion: "10.11.5-r3"
 dependencies:
 - name: chartlib

--- a/images/openldap/helm/Chart.yaml
+++ b/images/openldap/helm/Chart.yaml
@@ -7,7 +7,7 @@ sources:
 - https://git.openldap.org/openldap/openldap
 type: application
 version: 0.1.5
-appVersion: "2.6.6-r0"
+appVersion: "2.6.6-r1"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/samba-dc/Dockerfile
+++ b/images/samba-dc/Dockerfile
@@ -30,7 +30,7 @@ COPY *.conf.j2 /root/
 COPY entrypoint.sh /usr/local/bin/
 RUN apk add --update --no-cache krb5 ldb-tools samba-dc=$SAMBA_VERSION samba-winbind-clients=$SAMBA_VERSION tdb \
       bind bind-libs bind-tools libcrypto3 libxml2 tzdata py3-setuptools py3-pip && \
-    pip install j2cli && \
+    pip install j2cli --break-system-packages && \
     apk del py3-pip && \
     chmod 0755 /usr/local/bin/entrypoint.sh
 

--- a/images/weewx/Dockerfile
+++ b/images/weewx/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.18
 MAINTAINER Rich Braun "docker@instantlinux.net"
 ARG BUILD_DATE
 ARG VCS_REF

--- a/k8s/helm/gitlab/Chart.yaml
+++ b/k8s/helm/gitlab/Chart.yaml
@@ -7,8 +7,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://gitlab.com/gitlab-org/gitlab
 type: application
-version: 0.1.8
-appVersion: "16.5.0-ce.0"
+version: 0.1.9
+appVersion: "16.6.2-ce.0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/guacamole/Chart.yaml
+++ b/k8s/helm/guacamole/Chart.yaml
@@ -7,15 +7,15 @@ sources:
 - https://github.com/apache/guacamole-client
 - https://github.com/apache/guacamole-server
 type: application
-version: 0.1.3
-appVersion: "1.5.3"
+version: 0.1.4
+appVersion: "1.5.4"
 dependencies:
 - name: chartlib
   version: 0.1.8
   repository: https://instantlinux.github.io/docker-tools
 - name: guacamole-server
-  version: 0.1.2
+  version: 0.1.3
   repository: file://subcharts/guacamole-server
 - name: guacd
-  version: 0.1.2
+  version: 0.1.3
   repository: file://subcharts/guacd

--- a/k8s/helm/guacamole/subcharts/guacamole-server/Chart.yaml
+++ b/k8s/helm/guacamole/subcharts/guacamole-server/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/apache/guacamole-server
 type: application
-version: 0.1.2
-appVersion: "1.5.3"
+version: 0.1.3
+appVersion: "1.5.4"
 dependencies:
 - name: chartlib
   version: 0.1.5

--- a/k8s/helm/guacamole/subcharts/guacd/Chart.yaml
+++ b/k8s/helm/guacamole/subcharts/guacd/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/apache/guacamole-client
 type: application
-version: 0.1.2
-appVersion: "1.5.3"
+version: 0.1.3
+appVersion: "1.5.4"
 dependencies:
 - name: chartlib
   version: 0.1.5

--- a/k8s/helm/splunk/Chart.yaml
+++ b/k8s/helm/splunk/Chart.yaml
@@ -15,8 +15,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://hub.docker.com/r/splunk/splunk
 type: application
-version: 0.1.8
-appVersion: "9.1.1"
+version: 0.1.9
+appVersion: "9.1.2"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/lib/build/Makefile.docker_image
+++ b/lib/build/Makefile.docker_image
@@ -25,6 +25,10 @@ endif
 ifeq ($(IMAGE),nagiosql)
   PLATFORMS = linux/amd64,linux/arm64,linux/arm/v7
 endif
+ifeq ($(IMAGE),postfix-python)
+  # qemu bombs out with cpu_exec assertion since Dec 2023 on arm/v7
+  PLATFORMS = linux/amd64,linux/aarch64,linux/arm64
+endif
 ifeq ($(IMAGE),$(filter $(IMAGE),python-builder python-wsgi))
   # helm package on arm/v6 isn't supported as of Aug 2021
   #  others had issues with pipenv hashes Jul 2023


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Revert haproxy-keepalived and weewx
* Remove arm/v7 support for postfix-python because of weird problem with qemu on gitlab runner
* Add the --break-system-packages flag to make samba-dc's Dockerfile run pip (had to do this for other images)
* Upgrade charts of these third party images: gitlab, guacamole, splunk

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
New version of haproxy 2.9.x fails to run in my environment (100% CPU, takes down all services on all k8s workers after a short time, it's quite a sight to behold). The source repo for weewx is woefully outdated (no updates in 10 months) and I cannot find a way to make it run under alpine 3.19 without reverting py3-pillow somehow.

The other changes are routine security updates and housekeeping.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Lots of local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
