### PR TITLE
add util-linux dependency

### DIFF
--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -27,7 +27,7 @@ HEALTHCHECK CMD upsc $NAME@localhost:3493 2>&1|grep -q stale && \
     kill -SIGTERM -1 || true
 
 RUN apk add --update nut=$NUT_VERSION \
-      libcrypto3 libssl3 libusb musl net-snmp-libs
+      libcrypto3 libssl3 libusb musl net-snmp-libs util-linux
 
 EXPOSE 3493
 COPY entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
## Summary of Changes
At times the application tries to use kill if it discovers a .pid (may be after a reboot) and the wall command, these two commands are available in util-linux

## Why is this change being made?

Error, command not found (kill and wall)

## How was this tested? How can the reviewer verify your testing?

When starting the process, after a few minutes a wall command not found error appeared

## Completion checklist

- [ ] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [ ] Documentation has been updated
- [ ] Dependencies have been updated and verified
