### PR TITLE
Issue #149 security patch updates for nut-upsd

### DIFF
--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -28,8 +28,13 @@ HEALTHCHECK CMD upsc $NAME@localhost:3493 2>&1|grep -q stale && \
 
 RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/community' \
       >>/etc/apk/repositories && \
+    echo '@edgemain http://dl-cdn.alpinelinux.org/alpine/edge/main' \
+      >>/etc/apk/repositories && \
+    apk add --no-cache dash@edgemain && \
     apk add --update --no-cache nut@edge=$NUT_VERSION \
-      libcrypto3 libssl3 libusb musl net-snmp-libs util-linux
+      busybox@edgemain linux-pam@edgemain \
+      libcrypto3@edgemain libssl3@edgemain \
+      libusb musl net-snmp-libs util-linux
 
 EXPOSE 3493
 COPY entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Publish the nut-upsd image version `2.8.2`. Alpine 3.19 has some recently published CVE vulnerabilities that aren't yet fixed in the  stock image.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

The newest vulnerability corrections aren't available in the main repo, so this Dockerfile includes updates from edge repo.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing and CI.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
