### PR TITLE
SYS-633 image updates for Dec 2024

### DIFF
--- a/ansible/roles/docker_node/defaults/main.yml
+++ b/ansible/roles/docker_node/defaults/main.yml
@@ -81,4 +81,4 @@ ubuntu_repos:
   - deb {{ ubuntu_repo_uri }} {{ ansible_distribution_release }}-backports main restricted universe multiverse
   - deb {{ ubuntu_repo_uri }} {{ ansible_distribution_release }}-security main restricted universe multiverse
 
-local_package_additions: {}
+ubuntu_package_additions: []

--- a/images/data-sync/Dockerfile
+++ b/images/data-sync/Dockerfile
@@ -1,8 +1,7 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.license=Apache-2.0 \
     org.label-schema.name=data-sync \
     org.label-schema.vcs-ref=$VCS_REF \
@@ -16,9 +15,9 @@ ENV PEERNAME= \
     SSHKEY1=data-sync-sshkey1 \
     SSHKEY2=data-sync-sshkey2
 
-ARG UNISON_VERSION=2.53.5
+ARG UNISON_VERSION=2.53.7
 ARG OCAML_VERSION=4.14.2-r1
-ARG UNISON_SHA=330418ad130d93d0e13da7e7e30f9b829bd7c0e859355114bd4644c35fe08d23
+ARG UNISON_SHA=a259537cef465c4806d6c1638c382620db2dd395ae42a0dd2efa3ba92712bed5
 ARG RRSYNC_SHA=b745a37909fc10087cc9c901ad7dfda8ad8b6b493097b156b68ba33db4a5a52f
 
 COPY src/ /root/src/

--- a/images/data-sync/helm/Chart.yaml
+++ b/images/data-sync/helm/Chart.yaml
@@ -5,8 +5,8 @@ home: https://github.com/instantlinux/docker-tools
 sources:
 - https://github.com/instantlinux/docker-tools
 type: application
-version: 0.1.13
-appVersion: "2.53.5-4.14.2-r1"
+version: 0.1.14
+appVersion: "2.53.7-4.14.2-r1"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/ddclient/Dockerfile
+++ b/images/ddclient/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=GPL-2.0 \
     org.label-schema.name=ddclient \
     org.label-schema.vcs-ref=$VCS_REF \
@@ -15,11 +15,11 @@ ENV HOST= \
     SERVER=members.easydns.com \
     SERVICE_TYPE=easydns \
     USER_LOGIN= \
-    USER_SECRET=ddclient-user
+    USER_SECRETNAME=ddclient-user
 
 RUN apk add --no-cache --update curl ddclient=$DDCLIENT_VERSION \
       su-exec && \
     chown ddclient /var/cache/ddclient
 
 COPY entrypoint.sh /usr/local/bin/
-ENTRYPOINT /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/images/ddclient/README.md
+++ b/images/ddclient/README.md
@@ -20,7 +20,7 @@ Then deploy this service, see the example [helm](https://github.com/instantlinux
 | SERVER | members.easydns.com | remote dynamic-DNS server hostname|
 | SERVICE_TYPE | easydns | DNS vendor, see [available services](https://github.com/ddclient/ddclient/blob/develop/README.md)
 | USER_LOGIN | |Login name|
-| USER_SECRET | ddclient-user |Name of the Docker secret containing password |
+| USER_SECRETNAME | ddclient-user |Name of the Docker secret containing password |
 
 Instead of supplying these variables, if your provider requires more parameters than shown above, you can volume-mount the configuration as `/etc/ddclient/ddclient.conf`.
 

--- a/images/ddclient/entrypoint.sh
+++ b/images/ddclient/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-USER_PASSWORD=$(cat /run/secrets/$USER_SECRET)
+USER_PASSWORD=$(cat /run/secrets/$USER_SECRETNAME)
 
 if [ -z "$HOST" ]; then
     echo "** HOST must be specified **"

--- a/images/dovecot/Dockerfile
+++ b/images/dovecot/Dockerfile
@@ -1,18 +1,17 @@
-FROM instantlinux/postfix:3.8.3-r1
+FROM instantlinux/postfix:3.9.0-r1
 
-MAINTAINER Rich Braun "docker@instantlinux.net"
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.license=Apache-2.0 \
     org.label-schema.name=dovecot \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG DOVECOT_VERSION=2.3.21-r17
+ARG DOVECOT_VERSION=2.3.21.1-r0
 ARG MKCERT_SHA=24b6988d1709e71c24dcf94ffce5db93bd2e89dc5cbec1ac3c173de5274b68dd
 
-ENV LDAP_PASSWD_SECRET=ldap-ro-password \
+ENV LDAP_SECRETNAME=ldap-ro-password \
     SSL_DH=
 
 # TODO - procmail is missing from 3.12 repo, unsure if support ended

--- a/images/dovecot/README.md
+++ b/images/dovecot/README.md
@@ -43,7 +43,7 @@ See the Makefile and Makefile.vars files under k8s directory for default values 
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| LDAP_PASSWD_SECRET | ldap-ro-passwd | name of secret for LDAP credential |
+| LDAP_SECRETNAME | ldap-ro-passwd | name of secret for LDAP credential |
 | SSL_DH |  | Filename (in conf.local) of DH parameters |
 | TZ | UTC | time zone |
 

--- a/images/dovecot/entrypoint-dovecot.sh
+++ b/images/dovecot/entrypoint-dovecot.sh
@@ -33,11 +33,11 @@ else
 fi
 if [ -s $ETC/conf.local/dovecot-ldap.conf ]; then
   cp $ETC/conf.local/dovecot-ldap.conf $ETC
-  if [ -s /run/secrets/$LDAP_PASSWD_SECRET ]; then
-    sed -i -e "s/PASSWORD/`cat /run/secrets/$LDAP_PASSWD_SECRET`/" \
+  if [ -s /run/secrets/$LDAP_SECRETNAME ]; then
+    sed -i -e "s/PASSWORD/`cat /run/secrets/$LDAP_SECRETNAME`/" \
       $ETC/dovecot-ldap.conf
   else
-    echo "** Config dovecot-ldap.conf secret $LDAP_PASSWD_SECRET unspecified **"
+    echo "** Config dovecot-ldap.conf secret $LDAP_SECRETNAME unspecified **"
   fi
 fi
 if [ -f /etc/postfix/transport ]; then

--- a/images/ez-ipupdate/Dockerfile
+++ b/images/ez-ipupdate/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=GPL-2.0 \
     org.label-schema.name=ez-ipupdate \
     org.label-schema.vcs-ref=$VCS_REF \
@@ -13,12 +13,12 @@ ENV HOST= \
     INTERVAL=3600 \
     IPLOOKUP_URI=http://ipinfo.io/ip \
     SERVICE_TYPE=easydns \
-    USER_SECRET=ez-ipupdate-user
+    USER_SECRETNAME=ez-ipupdate-user
 
 RUN apk add --update curl ez-ipupdate=$EZ_VERSION && \
     rm -fr /var/log/* /var/cache/apk/*
 
-CMD sh -c 'echo "user=`cat /run/secrets/$USER_SECRET`" > /run/ez.conf && \
+CMD sh -c 'echo "user=`cat /run/secrets/$USER_SECRETNAME`" > /run/ez.conf && \
     if [ -z "$HOST" ]; then echo "Please set a HOST name"; exit 1; fi && \
     while [ 1 == 1 ]; do \
      IPADDR=`curl -s $IPLOOKUP_URI` && \

--- a/images/ez-ipupdate/README.md
+++ b/images/ez-ipupdate/README.md
@@ -20,7 +20,7 @@ Then deploy this service, see the example [helm](https://github.com/instantlinux
 | INTERVAL | 3600 | poll interval in seconds |
 | IPLOOKUP_URI | http://ipinfo.io/ip | a URI that returns the IPv4 address to be assigned |
 | SERVICE_TYPE | easydns | DNS vendor, see [available services](http://leaf.sourceforge.net/doc/bucu-ezipupd.html) |
-| USER_SECRET | ez-ipupdate-user |Name of the Docker secret to deploy |
+| USER_SECRETNAME | ez-ipupdate-user |Name of the Docker secret to deploy |
 
 This repo has complete instructions for
 [building a kubernetes cluster](https://github.com/instantlinux/docker-tools/blob/main/k8s/README.md) where you can deploy with [helm](https://github.com/instantlinux/docker-tools/tree/main/images/ez-ipupdate/helm) or [kubernetes.yaml](https://github.com/instantlinux/docker-tools/blob/main/images/ez-ipupdate/kubernetes.yaml) using _make_ and customizing [Makefile.vars](https://github.com/instantlinux/docker-tools/blob/main/k8s/Makefile.vars) after cloning this repo:

--- a/images/git-dump/Dockerfile
+++ b/images/git-dump/Dockerfile
@@ -1,13 +1,13 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=GPL-2.0 \
     org.label-schema.name=git-dump \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
-ENV API_TOKEN_SECRET= \
+ENV API_TOKEN_SECRETNAME= \
     DEST_DIR=/var/backup/git \
     HOUR=0 MINUTE=45 \
     KEEP_DAYS=31 \
@@ -15,12 +15,12 @@ ENV API_TOKEN_SECRET= \
     REPO_PREFIX=git@github.com:instantlinux/ \
     REPOS= \
     SCM_TYPE=github \
-    SSHKEY_SECRET=git-dump_sshkey \
+    SSHKEY_SECRETNAME=git-dump_sshkey \
     SSH_PORT=22 \
     USERNAME=git-dump \
     TZ=UTC
 
-ARG GIT_VERSION=2.45.2-r0
+ARG GIT_VERSION=2.47.1-r0
 ARG GROUP=care
 ARG GID=505
 ARG UID=212

--- a/images/git-dump/README.md
+++ b/images/git-dump/README.md
@@ -43,7 +43,7 @@ These variables can be passed to the image from kubernetes.yaml or docker-compos
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| API_TOKEN_SECRET | | docker secret name of API token as below |
+| API_TOKEN_SECRETNAME | | docker secret name of API token as below |
 | DEST_DIR | /var/backup/git | destination path |
 | HOUR | 0 |cron-syntax backup hour |
 | KEEP_DAYS | 31 | days of snapshots to keep |
@@ -52,7 +52,7 @@ These variables can be passed to the image from kubernetes.yaml or docker-compos
 | REPO_PREFIX | git@github.com:instantlinux/ | prefix for each repository URI |
 | REPOS | | repository URIs to back up |
 | SCM_TYPE | github | type - github, gitlab, or gitea |
-| SSHKEY_SECRET | git-dump_sshkey | docker secret name as below |
+| SSHKEY_SECRETNAME | git-dump_sshkey | docker secret name as below |
 | SSH_PORT | 22 | TCP port of git service |
 | TZ | UTC | time zone |
 

--- a/images/git-dump/entrypoint.sh
+++ b/images/git-dump/entrypoint.sh
@@ -6,20 +6,20 @@ if [ ! -f /etc/timezone ] && [ ! -z "$TZ" ]; then
   echo $TZ >/etc/timezone
 fi
 
-if [ -z "$REPOS" ] && [ ! -s /run/secrets/$API_TOKEN_SECRET ]; then
-  echo "** This container requires setting for REPOS or API_TOKEN_SECRET **"
+if [ -z "$REPOS" ] && [ ! -s /run/secrets/$API_TOKEN_SECRETNAME ]; then
+  echo "** This container requires setting for REPOS or API_TOKEN_SECRETNAME **"
   sleep 10
   exit 1
 fi
 
 SSH_PATH=/home/$USERNAME/.ssh
 mkdir -p -m 700 $SSH_PATH
-if [ ! -z "$SSHKEY_SECRET" ]; then
-  cp /run/secrets/$SSHKEY_SECRET $SSH_PATH/$SSHKEY_SECRET
-  chmod 400 $SSH_PATH/$SSHKEY_SECRET
+if [ ! -z "$SSHKEY_SECRETNAME" ]; then
+  cp /run/secrets/$SSHKEY_SECRETNAME $SSH_PATH/$SSHKEY_SECRETNAME
+  chmod 400 $SSH_PATH/$SSHKEY_SECRETNAME
   cat <<EOF >$SSH_PATH/config
 Host *
- IdentityFile $SSH_PATH/$SSHKEY_SECRET
+ IdentityFile $SSH_PATH/$SSHKEY_SECRETNAME
  Port $SSH_PORT
 EOF
   if [ ! -z "$REPO_PREFIX" ]; then
@@ -45,7 +45,7 @@ chown $USERNAME.$GROUP $DEST_DIR /var/log/git-dump.log /var/log/git-dump-status.
 
 cat <<EOF >/etc/opt/git-dump
 # Options for /usr/local/bin/git-dump
-API_TOKEN_SECRET=$API_TOKEN_SECRET
+API_TOKEN_SECRETNAME=$API_TOKEN_SECRETNAME
 LOGFILE=/var/log/git-dump.log
 REPO_PREFIX=$REPO_PREFIX
 STATFILE=/var/log/git-dump-status.txt

--- a/images/git-dump/git-dump.sh
+++ b/images/git-dump/git-dump.sh
@@ -9,7 +9,7 @@
 #  $2 number of files to keep
 #  $3-$ git repo suffixes
 
-# Omit git repo list if a API_TOKEN_SECRET is provided to query project
+# Omit git repo list if a API_TOKEN_SECRETNAME is provided to query project
 # list from gitlab
 
 DESTDIR=$1
@@ -44,9 +44,9 @@ else
  DAY=`date +%m%d`
 fi
 
-if [ ! -z "$API_TOKEN_SECRET" ] && [ -e /run/secrets/$API_TOKEN_SECRET ]; then
+if [ ! -z "$API_TOKEN_SECRETNAME" ] && [ -e /run/secrets/$API_TOKEN_SECRETNAME ]; then
   SSH_HOST=$(echo $REPO_PREFIX | cut -d@ -f 2 | cut -d/ -f 1 | cut -d: -f 1)
-  TOKEN=$(cat /run/secrets/$API_TOKEN_SECRET)
+  TOKEN=$(cat /run/secrets/$API_TOKEN_SECRETNAME)
   if [ $SCM_TYPE == github ]; then
     API_VERSION=v3
     API_PATH=repo

--- a/images/git-dump/helm/Chart.yaml
+++ b/images/git-dump/helm/Chart.yaml
@@ -5,8 +5,8 @@ home: https://github.com/instantlinux/docker-tools
 sources:
 - https://github.com/instantlinux/docker-tools
 type: application
-version: 0.1.14
-appVersion: "2.45.2-r0"
+version: 0.1.15
+appVersion: "2.47.1-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/git-pull/Dockerfile
+++ b/images/git-pull/Dockerfile
@@ -1,14 +1,14 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun <docker@instantlinux.net>
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=GPL-2.0 \
     org.label-schema.name=git-pull \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG GIT_VERSION=2.45.2-r0
+ARG GIT_VERSION=2.47.1-r0
 ENV DEST=. \
     GIT_COMMIT=master \
     GIT_HOST=github.com \
@@ -20,4 +20,4 @@ RUN apk add --no-cache --update git=$GIT_VERSION openssh-client && \
 VOLUME /git
 
 COPY entrypoint.sh /root/
-ENTRYPOINT /root/entrypoint.sh
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/images/git-pull/helm/Chart.yaml
+++ b/images/git-pull/helm/Chart.yaml
@@ -5,8 +5,8 @@ home: https://github.com/instantlinux/docker-tools
 sources:
 - https://github.com/instantlinux/docker-tools
 type: application
-version: 0.1.12
-appVersion: "2.45.2-r0"
+version: 0.1.13
+appVersion: "2.47.1-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/haproxy-keepalived/Dockerfile
+++ b/images/haproxy-keepalived/Dockerfile
@@ -1,18 +1,18 @@
-FROM haproxy:3.0.2-alpine
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM haproxy:3.1.1-alpine
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=GPL-2.0 \
     org.label-schema.name=haproxy-keepalived \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG KEEPALIVED_VERSION=2.2.8-r0
+ARG KEEPALIVED_VERSION=2.3.1-r0
 ENV KEEPALIVE_CONFIG_ID=main \
     PORT_HAPROXY_STATS=8080 \
     STATS_ENABLE=yes \
-    STATS_SECRET=haproxy-stats-password \
+    STATS_SECRETNAME=haproxy-stats-password \
     STATS_USER=haproxy \
     STATS_URI=/stats \
     TIMEOUT=50000 \

--- a/images/haproxy-keepalived/README.md
+++ b/images/haproxy-keepalived/README.md
@@ -43,7 +43,7 @@ These variables can be passed to the image from kubernetes.yaml or docker-compos
 |KEEPALIVE_CONFIG_ID| main | Which configuration to use (usually a hostname) |
 |PORT_HAPROXY_STATS| 8080 | What port to use for stats page |
 |STATS_ENABLE| yes | Whether to include stats | 
-|STATS_SECRET|haproxy-stats-password | Secret to use for stats page |
+|STATS_SECRETNAME|haproxy-stats-password | Secret to use for stats page |
 |STATS_USER|haproxy|Username for stats page basic-auth |
 |STATS_URI|/stats| URI for stats page |
 |TIMEOUT|50000| Timeout for haproxy (ms)|

--- a/images/haproxy-keepalived/entrypoint.sh
+++ b/images/haproxy-keepalived/entrypoint.sh
@@ -6,8 +6,8 @@ function graceful_stop() {
     sleep 1; exit 0
 }
 
-if [ -s /run/secrets/$STATS_SECRET ]; then
-  STATS_PASSWORD=$(cat /run/secrets/$STATS_SECRET)
+if [ -s /run/secrets/$STATS_SECRETNAME ]; then
+  STATS_PASSWORD=$(cat /run/secrets/$STATS_SECRETNAME)
 else
   STATS_PASSWORD=changeme
 fi

--- a/images/haproxy-keepalived/helm/Chart.yaml
+++ b/images/haproxy-keepalived/helm/Chart.yaml
@@ -7,8 +7,8 @@ sources:
 - https://github.com/haproxy/haproxy
 - https://github.com/acassen/keepalived
 type: application
-version: 0.1.15
-appVersion: "3.0.2-alpine-2.2.8-r0"
+version: 0.1.16
+appVersion: "3.1.1-alpine-2.3.1-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/mysqldump/Dockerfile
+++ b/images/mysqldump/Dockerfile
@@ -1,8 +1,7 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.license=Apache-2.0 \
     org.label-schema.name=mysqldump \
     org.label-schema.vcs-ref=$VCS_REF \
@@ -10,7 +9,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 
 ENV HOUR=3 MINUTE=30 \
     KEEP_DAYS=31 \
-    DB_CREDS_SECRET=mysql-backup-creds \
+    DB_CREDS_SECRETNAME=mysql-backup-creds \
     LOCK_FOR_BACKUP= \
     SERVERS=dbhost \
     SKEW_SECONDS=15 \
@@ -18,7 +17,7 @@ ENV HOUR=3 MINUTE=30 \
     TZ=UTC
 ARG UID=210
 ARG BACKUP_GID=34
-ARG CLIENT_VERSION=10.11.8-r0
+ARG CLIENT_VERSION=11.4.4-r1
 
 RUN RMGROUP=$(grep :$BACKUP_GID: /etc/group | cut -d: -f 1) && \
     [ -z "$RMGROUP" ] || delgroup $RMGROUP && \

--- a/images/mysqldump/README.md
+++ b/images/mysqldump/README.md
@@ -51,7 +51,7 @@ make mysqldump
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| DB_CREDS_SECRET | mysql-backup-creds | Name of secret |
+| DB_CREDS_SECRETNAME | mysql-backup-creds | Name of secret |
 | HOUR | 3 |cron-syntax backup hour |
 | KEEP_DAYS | 31 | days of snapshots to keep |
 | LOCK_FOR_BACKUP | | true if using Percona, blank for MariaDB |

--- a/images/mysqldump/entrypoint.sh
+++ b/images/mysqldump/entrypoint.sh
@@ -8,7 +8,7 @@ fi
 CNF=/home/$USERNAME/.my.cnf
 LOG=/var/log/mysqldump.log
 echo [client] > $CNF
-cat /run/secrets/$DB_CREDS_SECRET >> $CNF
+cat /run/secrets/$DB_CREDS_SECRETNAME >> $CNF
 
 touch $LOG
 chown $USERNAME /var/backup $LOG $CNF

--- a/images/mysqldump/helm/Chart.yaml
+++ b/images/mysqldump/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/mariadb/server/tree/10.5/client
 type: application
-version: 0.1.10
-appVersion: "10.11.8-r0"
+version: 0.1.11
+appVersion: "11.4.4-r1"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
 LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
@@ -26,14 +26,10 @@ ENV API_USER=upsmon \
 HEALTHCHECK CMD upsc $NAME@localhost:3493 2>&1|grep -q stale && \
     killall -TERM upsmon || true
 
-RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/community' \
-      >>/etc/apk/repositories && \
-    echo '@edgemain http://dl-cdn.alpinelinux.org/alpine/edge/main' \
-      >>/etc/apk/repositories && \
-    apk add --no-cache dash@edgemain && \
-    apk add --update --no-cache nut@edge=$NUT_VERSION \
-      busybox@edgemain linux-pam@edgemain \
-      libcrypto3@edgemain libssl3@edgemain \
+RUN apk add --no-cache dash && \
+    apk add --update --no-cache nut=$NUT_VERSION \
+      busybox linux-pam \
+      libcrypto3 libssl3 \
       libusb musl net-snmp-libs util-linux
 
 EXPOSE 3493

--- a/images/openldap/Dockerfile
+++ b/images/openldap/Dockerfile
@@ -1,14 +1,14 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=GPL-3.0 \
     org.label-schema.name=openldap \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG OPENLDAP_VERSION=2.6.7-r0
+ARG OPENLDAP_VERSION=2.6.8-r0
 ENV SLAPD_DN_ATTR=uid \
     SLAPD_FQDN=example.com \
     SLAPD_LOG_LEVEL=Config,Stats \
@@ -22,10 +22,10 @@ ENV SLAPD_DN_ATTR=uid \
     SLAPD_PWD_MIN_LENGTH=8 \
     SLAPD_ROOTDN= \
     SLAPD_ROOTPW_HASH= \
-    SLAPD_ROOTPW_SECRET=openldap-ro-password \
+    SLAPD_ROOTPW_SECRETNAME=openldap-ro-password \
     SLAPD_SUFFIX= \
     SLAPD_ULIMIT=2048 \
-    SLAPD_USERPW_SECRET=openldap-user-passwords
+    SLAPD_USERPW_SECRETNAME=openldap-user-passwords
 
 RUN apk add --update --no-cache gettext gzip openldap=$OPENLDAP_VERSION \
       openldap-clients openldap-back-mdb openldap-passwd-pbkdf2 \
@@ -38,4 +38,4 @@ COPY slapd.conf /root/
 COPY ldif/ /root/ldif/
 COPY entrypoint.sh /usr/local/bin/
 
-ENTRYPOINT /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/images/openldap/README.md
+++ b/images/openldap/README.md
@@ -35,10 +35,10 @@ make openldap
 | SLAPD_ROOTDN | cn=admin,dc=(suffix)  | Admin user's DN |
 | SLAPD_ROOTPW |  | Plain-text admin password |
 | SLAPD_ROOTPW_HASH |  | Hashed admin password |
-| SLAPD_ROOTPW_SECRET | openldap-ro-password | Name of secret to hold pw |
+| SLAPD_ROOTPW_SECRETNAME | openldap-ro-password | Name of secret to hold pw |
 | SLAPD_SUFFIX | (based on `SLAPD_FQDN`) | Suffix of DN |
 | SLAPD_ULIMIT | 2048 | maximum file size |
-| SLAPD_USERPW_SECRET | openldap-user-passwords | Name of secret to hold pws |
+| SLAPD_USERPW_SECRETNAME | openldap-user-passwords | Name of secret to hold pws |
 
 If overriding default root DN, it should be specified in the form `cn=admin,dc=example,dc=com`.
 

--- a/images/openldap/entrypoint.sh
+++ b/images/openldap/entrypoint.sh
@@ -16,12 +16,12 @@ if [ ! -d ${SLAPD_CONF_DIR} ]; then
     if [ ! -z "$SLAPD_ROOTPW" ]; then
         SLAPD_ROOTPW_HASH=$(slappasswd -o module-load=pw-pbkdf2.so \
            -h {PBKDF2-SHA512} -s "$SLAPD_ROOTPW")
-    elif [[ -z "$SLAPD_ROOTPW_HASH" && -s /run/secrets/$SLAPD_ROOTPW_SECRET ]]; then
+    elif [[ -z "$SLAPD_ROOTPW_HASH" && -s /run/secrets/$SLAPD_ROOTPW_SECRETNAME ]]; then
         SLAPD_ROOTPW_HASH=$(slappasswd -o module-load=pw-pbkdf2.so \
-           -h {PBKDF2-SHA512} -s "$(cat /run/secrets/$SLAPD_ROOTPW_SECRET)")
+           -h {PBKDF2-SHA512} -s "$(cat /run/secrets/$SLAPD_ROOTPW_SECRETNAME)")
     fi
     if [ -z "$SLAPD_ROOTPW_HASH" ]; then
-        echo "** Secret SLAPD_ROOTPW_SECRET unspecified **"
+        echo "** Secret SLAPD_ROOTPW_SECRETNAME unspecified **"
         exit 1
     fi
     export SLAPD_DATA_DIR
@@ -72,7 +72,7 @@ tail -f -n0 /var/log/slapd-audit.log |
 (   sleep 10
     # Post-startup actions
     echo 'Setting user passwords'
-    PW_FILE=$(find /run/secrets/$SLAPD_USERPW_SECRET -type f | head -1)
+    PW_FILE=$(find /run/secrets/$SLAPD_USERPW_SECRETNAME -type f | head -1)
     if [[ ! -z "${PW_FILE}" && -s "${PW_FILE}" ]]; then
         awk -F : -v dnattr=${SLAPD_DN_ATTR} \
 	  -v suffix=,${SLAPD_OU}${SLAPD_SUFFIX} \

--- a/images/openldap/helm/Chart.yaml
+++ b/images/openldap/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://git.openldap.org/openldap/openldap
 type: application
-version: 0.1.6
-appVersion: "2.6.7-r0"
+version: 0.1.7
+appVersion: "2.6.8-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/postfix-python/Dockerfile
+++ b/images/postfix-python/Dockerfile
@@ -1,16 +1,16 @@
-ARG POSTFIX_VERSION=3.9.0-r1
+ARG POSTFIX_VERSION=3.9.1-r0
 
 FROM instantlinux/postfix:$POSTFIX_VERSION
-MAINTAINER Rich Braun "docker@instantlinux.net"
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=IPL-1.0 \
     org.label-schema.name=postfix-python \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ENV BLACKLIST_USER_SECRET=mysql-blacklist-user \
+ENV BLACKLIST_USER_SECRETNAME=mysql-blacklist-user \
     CIDR_MIN_SIZE=32 \
     DB_HOST=dbhost \
     DB_NAME=blacklist \

--- a/images/postfix-python/README.md
+++ b/images/postfix-python/README.md
@@ -17,7 +17,7 @@ Messages flagged with a high spam score are diverted to subdirectories under /va
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| BLACKLIST_USER_SECRET | mysql-blacklist-user | MySQL cred secret name |
+| BLACKLIST_USER_SECRETNAME | mysql-blacklist-user | MySQL cred secret name |
 | CIDR_MIN_SIZE | 32 | size of netblock to blacklist |
 | DB_HOST | dbhost | database host or IP |
 | DB_NAME | blacklist | db name |

--- a/images/postfix-python/helm/Chart.yaml
+++ b/images/postfix-python/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/vdukhovni/postfix
 type: application
-version: 0.1.14
-appVersion: "3.9.0-r1"
+version: 0.1.15
+appVersion: "3.9.1-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/postfix-python/src/postfix-extras.sh
+++ b/images/postfix-python/src/postfix-extras.sh
@@ -17,7 +17,7 @@ if [ ! -f $DB_CFG ]; then
 host=$DB_HOST
 database=$DB_NAME
 EOF
-  cat /run/secrets/$BLACKLIST_USER_SECRET >> $DB_CFG
+  cat /run/secrets/$BLACKLIST_USER_SECRETNAME >> $DB_CFG
   cat > /home/spamfilter/.profile <<EOF
 export CIDR_MIN_SIZE=$CIDR_MIN_SIZE
 export DB_USER=$DB_USER

--- a/images/postfix/Dockerfile
+++ b/images/postfix/Dockerfile
@@ -1,14 +1,14 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=IPL-1.0 \
     org.label-schema.name=postfix \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
-ARG POSTFIX_VERSION=3.9.0-r1
-ENV SASL_PASSWD_SECRET=postfix-sasl-passwd \
+ARG POSTFIX_VERSION=3.9.1-r0
+ENV SASL_SECRETNAME=postfix-sasl-passwd \
     TZ=UTC
 
 RUN apk add --no-cache --update \

--- a/images/postfix/README.md
+++ b/images/postfix/README.md
@@ -24,7 +24,7 @@ See etc-example directory and kubernetes.yaml / docker-compose.yml.
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| SASL_PASSWD_SECRET | postfix-sasl-passwd | name of secret for SASL map |
+| SASL_SECRETNAME | postfix-sasl-passwd | name of secret for SASL map |
 | TZ | UTC | time zone |
 
 ### Secrets

--- a/images/postfix/entrypoint.sh
+++ b/images/postfix/entrypoint.sh
@@ -34,8 +34,8 @@ done
 [ -x users.sh ] && ./users.sh
 newaliases
 cd ..
-if [ -s /run/secrets/$SASL_PASSWD_SECRET ]; then
-  cp /run/secrets/$SASL_PASSWD_SECRET sasl_passwd
+if [ -s /run/secrets/$SASL_SECRETNAME ]; then
+  cp /run/secrets/$SASL_SECRETNAME sasl_passwd
   postmap sasl_passwd
   chmod 600 sasl_passwd*
 fi

--- a/images/proftpd/Dockerfile
+++ b/images/proftpd/Dockerfile
@@ -1,20 +1,20 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=GPL-2.0 \
     org.label-schema.name=proftpd \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG PROFTPD_VERSION=1.3.8b-r2
+ARG PROFTPD_VERSION=1.3.8c-r0
 
 ENV ALLOW_OVERWRITE=on \
     ANONYMOUS_DISABLE=off \
     ANON_UPLOAD_ENABLE=DenyAll \
-    FTPUSER_PASSWORD_SECRET=ftp-user-password-secret \
     FTPUSER_NAME=ftpuser \
+    FTPUSER_SECRETNAME=ftp-user-password-secret \
     FTPUSER_UID=1001 \
     LOCAL_UMASK=022 \
     MAX_CLIENTS=10 \

--- a/images/proftpd/README.md
+++ b/images/proftpd/README.md
@@ -33,8 +33,8 @@ Variable | Default | Description |
 ALLOW_OVERWRITE | on | allow clients to modify files
 ANONYMOUS_DISABLE | off | anonymous login
 ANON_UPLOAD_ENABLE | DenyAll | anonymous upload
-FTPUSER_PASSWORD_SECRET | ftp-user-password-secret | hashed pw of upload user
 FTPUSER_NAME | ftpuser | upload username
+FTPUSER_SECRETNAME | ftp-user-password-secret | name of hashed pw secret
 FTPUSER_UID | 1001 | upload file ownership UID
 LOCAL_UMASK | 022 | upload umask
 MAX_CLIENTS | 10 | maximum simultaneous logins

--- a/images/proftpd/entrypoint.sh
+++ b/images/proftpd/entrypoint.sh
@@ -12,9 +12,9 @@ if [ -z "$PASV_ADDRESS" ]; then
   exit 1
 fi
 
-if [ -e /run/secrets/$FTPUSER_PASSWORD_SECRET ] && ! id -u "$FTPUSER_NAME"; then
+if [ -e /run/secrets/$FTPUSER_SECRETNAME ] && ! id -u "$FTPUSER_NAME"; then
   adduser -u $FTPUSER_UID -s /bin/sh -g "ftp user" -D $FTPUSER_NAME
-  echo "$FTPUSER_NAME:$(cat /run/secrets/$FTPUSER_PASSWORD_SECRET)" \
+  echo "$FTPUSER_NAME:$(cat /run/secrets/$FTPUSER_SECRETNAME)" \
     | chpasswd -e
 fi
 

--- a/images/proftpd/helm/Chart.yaml
+++ b/images/proftpd/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/proftpd/proftpd
 type: application
-version: 0.1.9
-appVersion: "1.3.8b-r2"
+version: 0.1.10
+appVersion: "1.3.8c-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/rsyslogd/Dockerfile
+++ b/images/rsyslogd/Dockerfile
@@ -1,14 +1,13 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.license=GPL-3.0 \
     org.label-schema.name=rsyslogd \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG RSYSLOG_VERSION=8.2404.0-r0
+ARG RSYSLOG_VERSION=8.2410.0-r0
 ENV TZ=UTC
 RUN apk add --update gzip logrotate rsyslog=$RSYSLOG_VERSION \
       rsyslog-mysql=$RSYSLOG_VERSION tar xz && \
@@ -21,4 +20,4 @@ COPY rsyslog-rotate /etc/logrotate.d/rsyslog
 RUN chmod 644 /etc/logrotate.conf
 
 ADD entrypoint.sh /root/
-ENTRYPOINT /root/entrypoint.sh
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/images/rsyslogd/helm/Chart.yaml
+++ b/images/rsyslogd/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/rsyslog/rsyslog
 type: application
-version: 0.1.11
-appVersion: "8.2404.0-r0"
+version: 0.1.12
+appVersion: "8.2410.0-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/samba/Dockerfile
+++ b/images/samba/Dockerfile
@@ -1,14 +1,14 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=GPL-3.0 \
     org.label-schema.name=samba \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG SAMBA_VERSION=4.19.6-r0
+ARG SAMBA_VERSION=4.20.6-r1
 ENV LOGON_DRIVE=H \
     NETBIOS_NAME=samba \
     SERVER_STRING="Samba Server" \

--- a/images/samba/helm/Chart.yaml
+++ b/images/samba/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://gitlab.com/samba-team/samba
 type: application
-version: 0.1.13
-appVersion: "4.19.6-r0"
+version: 0.1.14
+appVersion: "4.20.6-r1"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/gitea/Chart.yaml
+++ b/k8s/helm/gitea/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/go-gitea/gitea
 type: application
-version: 0.1.2
-appVersion: 1.22.4-rootless
+version: 0.1.3
+appVersion: 1.22.6-rootless
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/restic/Chart.yaml
+++ b/k8s/helm/restic/Chart.yaml
@@ -6,10 +6,10 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/restic/restic
 type: application
-version: 0.1.11
+version: 0.1.12
 # Remember to update restic==<ver> in values.yaml as releases are published;
 #  the values.yaml file is not able to reference .Chart.appVersion
-appVersion: "0.16.4-r5"
+appVersion: "0.17.3-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/restic/values.yaml
+++ b/k8s/helm/restic/values.yaml
@@ -16,7 +16,7 @@ deployment:
     mkdir -p /var/log/week && tail -f -n 0 /var/log/restic.log
   env:
     # Edit the version in Chart.yaml to keep consistent
-    app_version: 0.16.4-r5
+    app_version: 0.17.3-r0
     env: /etc/profile
     tz: UTC
   nodeSelector:

--- a/k8s/helm/splunk/Chart.yaml
+++ b/k8s/helm/splunk/Chart.yaml
@@ -15,8 +15,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://hub.docker.com/r/splunk/splunk
 type: application
-version: 0.1.11
-appVersion: "9.3.2"
+version: 0.1.12
+appVersion: "9.4.0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/vaultwarden/Chart.yaml
+++ b/k8s/helm/vaultwarden/Chart.yaml
@@ -5,8 +5,8 @@ home: https://github.com/instantlinux/docker-tools
 sources:
 - https://github.com/instantlinux/docker-tools
 type: application
-version: 0.1.4
-appVersion: "1.32.5-alpine"
+version: 0.1.5
+appVersion: "1.32.6-alpine"
 dependencies:
 - name: chartlib
   version: 0.1.8


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Alpine:3.21 is out. This update includes:

* images: data-sync, ddclient, dovecot, ez-ipupdate, git-dump, git-pull, haproxy-keepalived, mysqldump, nut-upsd, openldap, postfix, postfix-python, proftpd, rsyslogd, samba.
* helm charts: gitea, restic, splunk, vaultwarden

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Routine security-vulnerability maintenance.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing and CI.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
