### PR TITLE
SYS-633 fix chown commands for ddclient / git-dump

### DIFF
--- a/images/ddclient/entrypoint.sh
+++ b/images/ddclient/entrypoint.sh
@@ -18,8 +18,8 @@ ssl=yes
 server=$SERVER, protocol=$SERVICE_TYPE, login=$USER_LOGIN, password=$USER_PASSWORD $HOST
 EOF
 fi
-chown ddclient.ddclient /etc/ddclient/ddclient.conf
-chmod 400 /etc/ddclient/ddclient:conf
+chown ddclient:ddclient /etc/ddclient/ddclient.conf
+chmod 400 /etc/ddclient/ddclient.conf
 mkdir -p /run/ddclient && chown ddclient /run/ddclient
 
 exec su-exec ddclient /usr/bin/ddclient -foreground -verbose

--- a/images/ddclient/entrypoint.sh
+++ b/images/ddclient/entrypoint.sh
@@ -19,7 +19,7 @@ server=$SERVER, protocol=$SERVICE_TYPE, login=$USER_LOGIN, password=$USER_PASSWO
 EOF
 fi
 chown ddclient.ddclient /etc/ddclient/ddclient.conf
-chmod 400 /etc/ddclient/ddclient.conf
+chmod 400 /etc/ddclient/ddclient:conf
 mkdir -p /run/ddclient && chown ddclient /run/ddclient
 
 exec su-exec ddclient /usr/bin/ddclient -foreground -verbose

--- a/images/git-dump/Dockerfile
+++ b/images/git-dump/Dockerfile
@@ -9,6 +9,7 @@ LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 ENV API_TOKEN_SECRETNAME= \
     DEST_DIR=/var/backup/git \
+    GROUP=care \
     HOUR=0 MINUTE=45 \
     KEEP_DAYS=31 \
     ORG= \
@@ -21,7 +22,6 @@ ENV API_TOKEN_SECRETNAME= \
     TZ=UTC
 
 ARG GIT_VERSION=2.47.1-r0
-ARG GROUP=care
 ARG GID=505
 ARG UID=212
 

--- a/images/git-dump/entrypoint.sh
+++ b/images/git-dump/entrypoint.sh
@@ -41,7 +41,7 @@ chown -R $USERNAME /home/$USERNAME
 [ -e /var/log/git-dump.log ] || touch /var/log/git-dump.log
 [ -e /var/log/git-dump-status.txt ] || touch /var/log/git-dump-status.txt
 mkdir -p -m 750 $DEST_DIR
-chown $USERNAME.$GROUP $DEST_DIR /var/log/git-dump.log /var/log/git-dump-status.txt
+chown $USERNAME:$GROUP $DEST_DIR /var/log/git-dump.log /var/log/git-dump-status.txt
 
 cat <<EOF >/etc/opt/git-dump
 # Options for /usr/local/bin/git-dump


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Fixes broken builds of ddclient and git-dump images.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

The syntax of `chown` permitted a deprecated format _owner.group_ until alpine:3.21. Replace the dot with a colon wherever this appeared.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing and CI.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
