### PR TITLE
SYS-633 mysqldump update for version 11.x, and nagios 4.5.8

### DIFF
--- a/images/mysqldump/mysql-backup.sh
+++ b/images/mysqldump/mysql-backup.sh
@@ -12,8 +12,8 @@
 
 USER=bkp
 LOG=/var/log/mysqldump.log
-MYSQL=/usr/bin/mysql
-MYSQLDUMP=/usr/bin/mysqldump
+MYSQL=/usr/bin/mariadb
+MYSQLDUMP=/usr/bin/mariadb-dump
 
 log_entry () {
  IL_PRIORITY=$1
@@ -30,7 +30,7 @@ log_entry info START
 # Grants required for bkp user:
 # GRANT SELECT,RELOAD,SUPER,REPLICATION CLIENT ON *.* TO '$USER'@'192.168.%' IDENTIFIED BY '$PSWD';
 
-DUMPOPTS="--force --skip-opt --quick --single-transaction \
+DUMPOPTS="--force --skip-opt --skip-ssl --quick --single-transaction \
  $OPT_LOCK_FOR_BACKUP --add-drop-table --set-charset --create-options \
  --no-autocommit --extended-insert --routines"
 SCHEMA_DUMP_OPTS=" --force --no-data --triggers --events --routines" 
@@ -74,8 +74,7 @@ do
     DBNAMES=`$MYSQL $OPTS -se "$DBNAME_QUERY"`
     STATFILE=$DESTDIR/$SERVER/mysqldump-status.txt
     # Grants
-    $MYSQL $OPTS -se "SELECT CONCAT('SHOW GRANTS FOR \'',user,'\'@\'',host,'\';') FROM mysql.user;" | \
-      $MYSQL $OPTS -s | awk '{print $0";"}' >$DESTDIR/$SERVER/$DAY/allgrants.sql
+    $MYSQLDUMP $OPTS --system=users >$DESTDIR/$SERVER/$DAY/allgrants.sql
 
     for DBNAME in $DBNAMES; do
       # Schema only

--- a/images/nagios/Dockerfile
+++ b/images/nagios/Dockerfile
@@ -1,17 +1,16 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.license=GPL-2.0 \
     org.label-schema.name=nagios \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG NAGIOS_VERSION=4.5.2-r0
+ARG NAGIOS_VERSION=4.5.8-r0
 ARG NAGIOS_GID=1000
 ARG NAGIOS_UID=999
-ARG PLUGINS_VERSION=2.4.5-r1
+ARG PLUGINS_VERSION=2.4.10-r0
 ARG WWW_UID=33
 ENV AUTHORIZED_USERS=nagiosadmin \
     CONFIG_CHECK=yes \
@@ -29,9 +28,7 @@ RUN addgroup -g $NAGIOS_GID nagios && \
     adduser -g www-data -u $WWW_UID -DSH -h /var/www www-data && \
     adduser -G nagios -g "Nagios Server" -DSH -h /var/nagios -u $NAGIOS_UID \
       nagios && \
-    echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' \
-      >>/etc/apk/repositories && \
-    apk add --update --no-cache nagios@edge=$NAGIOS_VERSION nagios-web \
+    apk add --update --no-cache nagios=$NAGIOS_VERSION nagios-web \
       nagios-plugins-all=$PLUGINS_VERSION \
       nagios-plugins-mysql=$PLUGINS_VERSION \
       nrpe-plugin bash curl fcgiwrap file mariadb-client nginx openssl \

--- a/images/nagios/entrypoint.sh
+++ b/images/nagios/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 sed -i -e "s/=nagiosadmin/=$AUTHORIZED_USERS/" /etc/nagios/cgi.cfg
 if [ -s /run/secrets/$HTPASSWD_SECRET ]; then
   cp /run/secrets/$HTPASSWD_SECRET /etc/nagios/htpasswd.users
-  chown root.www-data /etc/nagios/htpasswd.users
+  chown root:www-data /etc/nagios/htpasswd.users
   chmod 640 /etc/nagios/htpasswd.users
 fi
 
@@ -81,7 +81,7 @@ AuthUser=$MAIL_AUTH_USER
 EOF
   fi
 fi
-chown root.nagios /etc/ssmtp/ssmtp.conf
+chown root:nagios /etc/ssmtp/ssmtp.conf
 chmod 640 /etc/ssmtp/ssmtp.conf
 
 # Check configuration for errors
@@ -97,7 +97,7 @@ start-stop-daemon -u nginx -b --exec /usr/bin/fcgiwrap -- \
 /usr/sbin/php-fpm82
 /usr/sbin/nginx
 touch /var/nagios/nagios.log && tail -1 -f /var/nagios/nagios.log &
-find /var/nagios -not -user nagios -exec chown nagios.nagios {} \;
-find /etc/nagios/objects -not -user www-data -exec chown www-data.nagios {} \;
+find /var/nagios -not -user nagios -exec chown nagios:nagios {} \;
+find /etc/nagios/objects -not -user www-data -exec chown www-data:nagios {} \;
 
 exec /usr/sbin/nagios /etc/nagios/nagios.cfg


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Overrides the new default for mariadb-dump with `--skip-ssl`, fixes allgrants.sql dump, and eliminates deprecated names. (For historic reasons, still keeping the image name mysqldump even though it's been mariadb for years.) 

Updates nagios to 4.5.8.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

Routine security updates.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing and CI.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
