### PR TITLE
SYS-633 update image and ansible for mythtv v34, and fix mysqldump image

### DIFF
--- a/ansible/roles/mythfrontend/defaults/main.yml
+++ b/ansible/roles/mythfrontend/defaults/main.yml
@@ -10,10 +10,10 @@ display_driver_defaults:
   type: nvidia
   download: False
   nvidia:
-    checksum: d2cf81b5994a1728dc4851cdf0480cde0a34b040c94de0d5265edcfe3b90680a
+    checksum: 0a7aa742c46bcf34d766982402d17b3db1fdb3bc1b89344d70cd123c1cb3147c
     creates: /usr/lib64/xorg/modules/libnvidia-wfb.so.1
     download_uri: http://us.download.nvidia.com/XFree86/Linux-x86_64
-    version: 340.101
+    version: 565.77
   packages:
   - nvidia-304
   screen:
@@ -227,56 +227,7 @@ ir_device:
 mythdb_overrides: {}
 db: "{{ db_defaults | combine(mythdb_overrides) }}"
 
-mythtv_version: 33
-
-opensuse_packages:
-  - ImageMagick-devel
-  - kdm
-  - libdvdcss
-  - liblirc_client0=0.9.0
-  - lirc=0.9.0
-  - lirc-remotes=0.9.0
-  - kernel-default
-  - kernel-devel
-  - kernel-headers
-  - kernel-source
-  - mythtv-frontend
-  - MozillaFirefox
-  - mariadb-client
-  - mythtv-base-themes
-  - mythtv-common
-  - nrpe
-  - nagios-plugins
-  - net-snmp
-  - ntp
-  - patterns-openSUSE-kde4
-  - perl-Crypt-DES
-  - perl-mythtv
-  - perl-Net-CIDR
-  - perl-Net-Server
-  - perl-Net-SNMP
-  - perl-TimeDate
-  - python-mysql
-  - python-mythtv
-  - rsyslog
-  - v4l-utils
-  - xdm
-  - xkeyboard-config
-  - xorg-x11-driver-input
-  - xorg-x11-driver-video
-  - xorg-x11-fonts
-
-opensuse_repo_defaults:
-  - name: oss
-    repo: http://download.opensuse.org/distribution/leap/42.2/repo/oss/suse
-  - name: ossupd
-    repo: http://download.opensuse.org/update/leap/42.2/oss/
-  - name: packman
-    repo: http://packman.inode.at/suse/openSUSE_Leap_42.2/
-    flags: -f --keep-packages
-
-opensuse_repo_additions: []
-opensuse_repos: "{{ opensuse_repo_defaults + opensuse_repo_additions }}"
+mythtv_version: 34
 
 network_defaults:
   address: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"

--- a/ansible/roles/mythfrontend/tasks/main.yml
+++ b/ansible/roles/mythfrontend/tasks/main.yml
@@ -9,13 +9,7 @@
     state: directory
 
 - include_tasks: "{{ ansible_os_family | lower }}/packages.yml"
-- include_tasks: "{{ ansible_os_family | lower }}/lirc.yml"
-  when: ansible_distribution_version < '18.04'
-- include_tasks: "{{ ansible_os_family | lower }}/network.yml"
-  when: ansible_distribution_version < '18.04'
-
 - include_tasks: "{{ ansible_os_family | lower }}/ir-keytable.yml"
-  when: ansible_distribution_version >= '18.04'
 
 - include_tasks: autosuspend.yml
   when: suspend

--- a/ansible/roles/mythfrontend/tasks/vars/noble.yml
+++ b/ansible/roles/mythfrontend/tasks/vars/noble.yml
@@ -1,0 +1,2 @@
+---
+x11_config_path: /usr/share/X11/xorg.conf.d

--- a/images/mysqldump/Dockerfile
+++ b/images/mysqldump/Dockerfile
@@ -13,6 +13,7 @@ ENV HOUR=3 MINUTE=30 \
     LOCK_FOR_BACKUP= \
     SERVERS=dbhost \
     SKEW_SECONDS=15 \
+    SKIP_SSL=true \
     USERNAME=mysqldump \
     TZ=UTC
 ARG UID=210

--- a/images/mysqldump/README.md
+++ b/images/mysqldump/README.md
@@ -58,6 +58,7 @@ make mysqldump
 | MINUTE | 30 | cron-syntax minutes past hour |
 | SERVERS | dbhost | servers (space-separated list) to back up |
 | SKEW_SECONDS | 15 | wait between dumps |
+| SKIP_SSL | true | adjust if SSL desired |
 | USERNAME | mysqldump | username to run as |
 | TZ | UTC | time zone |
 

--- a/images/mysqldump/entrypoint.sh
+++ b/images/mysqldump/entrypoint.sh
@@ -9,6 +9,7 @@ CNF=/home/$USERNAME/.my.cnf
 LOG=/var/log/mysqldump.log
 echo [client] > $CNF
 cat /run/secrets/$DB_CREDS_SECRETNAME >> $CNF
+[ $SKIP_SSL = true ] && echo "skip-ssl=true" >> $CNF
 
 touch $LOG
 chown $USERNAME /var/backup $LOG $CNF

--- a/images/mysqldump/mysql-backup.sh
+++ b/images/mysqldump/mysql-backup.sh
@@ -30,7 +30,7 @@ log_entry info START
 # Grants required for bkp user:
 # GRANT SELECT,RELOAD,SUPER,REPLICATION CLIENT ON *.* TO '$USER'@'192.168.%' IDENTIFIED BY '$PSWD';
 
-DUMPOPTS="--force --skip-opt --skip-ssl --quick --single-transaction \
+DUMPOPTS="--force --skip-opt --quick --single-transaction \
  $OPT_LOCK_FOR_BACKUP --add-drop-table --set-charset --create-options \
  --no-autocommit --extended-insert --routines"
 SCHEMA_DUMP_OPTS=" --force --no-data --triggers --events --routines" 

--- a/images/mythtv-backend/Dockerfile
+++ b/images/mythtv-backend/Dockerfile
@@ -1,8 +1,7 @@
-FROM ubuntu:jammy
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM ubuntu:noble
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.license=GPL-2.0 \
     org.label-schema.name=mythtv-backend \
     org.label-schema.vcs-ref=$VCS_REF \
@@ -18,11 +17,11 @@ ENV APACHE_LOG_DIR=/var/log/apache2 \
     LOCALHOSTNAME= \
     TZ=UTC
 
-ARG APT_KEY=13551B881504888C
+ARG APT_SIG=13551B881504888C
 ARG MYTHTV_GID=100
 ARG MYTHTV_UID=2021
-ARG MYTHTV_PPA=http://ppa.launchpad.net/mythbuntu/33
-ARG MYTHTV_VERSION=2:33.1+fixes.202405301110.512d723c83~ubuntu22.04.1
+ARG MYTHTV_PPA=http://ppa.launchpad.net/mythbuntu/34
+ARG MYTHTV_VERSION=2:34.0+fixes.202501030536.ac34c663b2~ubuntu24.04.1
 ARG SSH_PORT=2022
 ARG MYTHWEB_PORT=6760
 ARG PPA_BRANCH=33
@@ -31,11 +30,13 @@ ARG MYTHLINK_SHA=459cb8b60adae4b631a95a9cfb1b41dcb959cc4a0b9053582a711d58b8d8a0d
 RUN \
   apt-get -yq update && \
   apt-get install -yq gnupg locales wget && \
-  apt-key adv --recv-keys --keyserver keyserver.ubuntu.com $APT_KEY && \
-  echo "deb $MYTHTV_PPA/ubuntu jammy main" \
+  apt-key adv --recv-keys --keyserver keyserver.ubuntu.com $APT_SIG && \
+  echo "deb $MYTHTV_PPA/ubuntu noble main" \
     > /etc/apt/sources.list.d/mythbuntu.list && \
   apt-get -yq update && \
   locale-gen $LANG && \
+  echo "# added via Dockerfile\npath-include=/usr/share/doc/mythtv-backend/contrib/*" > \
+   /etc/dpkg/dpkg.cfg.d/mythtv-backend && \
   apt-get -yq --no-install-recommends install \
     apache2 curl iputils-ping less lsb-release mariadb-client net-tools \
     openssh-client openssh-server mythtv-backend=$MYTHTV_VERSION \
@@ -55,10 +56,7 @@ RUN \
   mkdir -p /var/lib/mythtv $APACHE_LOG_DIR && \
   echo "mythtv:mythtv" | chpasswd && \
   chown $MYTHTV_UID:$MYTHTV_GID /var/lib/mythtv && \
-  wget -O /usr/bin/mythlink.pl -q \
-    https://raw.githubusercontent.com/MythTV/mythtv/fixes/${PPA_BRANCH}/mythtv/contrib/user_jobs/mythlink.pl && \
-  echo "$MYTHLINK_SHA  /usr/bin/mythlink.pl" | sha256sum -c && \
-  chmod 755 /usr/bin/mythlink.pl
+  ln -s /usr/share/doc/mythtv-backend/contrib/user_jobs/mythlink.pl /usr/bin
 
 EXPOSE $MYTHWEB_PORT $SSH_PORT 5000/udp 5002/udp 5004/udp 6543 6544 6549 \
   65001 65001/udp 


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Update mythtv-backend image to version 34.0. Clean out some of the deprecated opensuse support in mythfrontend ansible.

Rework the skip-ssl parameter in mysqldump (first added with PR #179).

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

Routine security and version updates.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing and CI.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
