### PR TITLE
SYS-636 housecleaning - ansible and helm

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -1,5 +1,5 @@
 VENV      ?= python_env
-VDIR      ?= $(PWD)/$(VENV)
+VDIR      ?= $(HOME)/$(VENV)
 INVENTORY ?= hosts
 
 test: test_requirements
@@ -16,8 +16,8 @@ python_env: $(VDIR)/bin/python
 test_requirements: python_env
 	@echo "Installing test requirements"
 	(. $(VDIR)/bin/activate && \
-	 pip install -r requirements.txt)
+	 pip install --break-system-packages -r requirements.txt)
 
 $(VDIR)/bin/python:
 	@echo "Creating virtual environment"
-	virtualenv --system-site-packages $(VENV)
+	python3 -m venv --system-site-packages $(VDIR)

--- a/ansible/roles/docker_node/defaults/main.yml
+++ b/ansible/roles/docker_node/defaults/main.yml
@@ -5,7 +5,7 @@ docker_defaults:
   apt_repo:
     key: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
     package_name: docker-ce
-    package_ver: 5:27.3.1-1~ubuntu.24.04~noble
+    package_ver: 5:27.5.1-1~ubuntu.24.04~noble
     repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
     url: https://download.docker.com/linux/ubuntu/gpg
   certs:

--- a/ansible/roles/monitoring_agent/files/plugins/check_ethtool.pl
+++ b/ansible/roles/monitoring_agent/files/plugins/check_ethtool.pl
@@ -1,0 +1,130 @@
+#! /usr/bin/perl
+
+# Check Linux media settings using ethtool
+# anders@fupp.net, 2007-09-19
+
+use Getopt::Std;
+getopts('i:s:d:a:hm');
+$ENV{'PATH'} = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+sub usage {
+	print "Usage: check_ethtool [-i <interface>] [-s 10|100|1000|10000]\n";
+	print "[-m (speed is minimum)] [-d <half|full>] [-a <on|off> (autoneg)] [-h (help)]\n";
+	exit(1);
+}
+
+if ($opt_h) { usage; }
+
+unless (defined($opt_a)) {
+	$opt_a = "ignored";
+}
+
+# Assume full duplex
+unless (defined($opt_d)) {
+	$opt_d = "full";
+}
+
+if ($opt_i) {
+	$if = $opt_i;
+} else {
+	# Try to guess interface name
+	$iflist = `ip -o r get 8.8.8.8`;
+	unless ($? == 0) { print "No ip command or problems with it? No interface specified with -i either.\n"; exit(2); }
+	foreach $ifline (split(/\n/, $iflist)) {
+		next if ($ifline =~ /bond/i);
+		if ($ifline =~ /\s+dev\s+(\S+)/) {
+			$if = $1;
+			# Use first pick
+			last;
+		}
+	}
+	unless (defined($if)) {
+		print "Could not find primary interface with ip command. No interface specified with -i either.\n"; exit(2);
+	}
+}
+
+%modes = ();
+
+$ethlines = "";
+foreach $line (`ethtool $if 2>&1`) {
+	chomp($line);
+	$ethlines .= $line . "\n";
+	if ($line =~ /^(\s+|)([\w -]+):\s+(\w+)/) {
+		$key = $2;
+		$val = $3;
+		$key =~ s@\s@_@g;
+		$key =~ tr@A-Z@a-z@;
+		$val =~ tr@A-Z@a-z@;
+
+		if ($key eq "speed") {
+			$val =~ s@\D+@@g;
+		}
+		if ($key eq "auto-negotiation") {
+			$key = "autoneg";
+		}
+		$modes{"$key"} = $val;
+	}
+}
+
+if ($? != 0) {
+	$ethlines =~ s@\n@ @g;
+	$ethlines =~ s@\s{2,}@ @g;
+	print "Ethtool exited with error: $ethlines\n";
+	exit(2);
+}
+
+if ($opt_s) {
+	$speed = $opt_s;
+} else {
+	$speed = 0;
+#	if ($ethlines =~ /Advertised link modes:\s+(.*)\n\t\w/im) {
+	if ($ethlines =~ /Supported link modes:\s+(.*?)\n\t\w/is) {
+		# Grab modes over multiple lines
+		$ethlines = $1;
+		# Change any whitespace to space
+		$ethlines =~ s@\s+@ @gs;
+		# Strip non digits
+		$ethlines =~ s@[^\d\s]@@g;
+		foreach $sspeed (split(/\s+/, $ethlines)) {
+			if ($sspeed > $curspeed) {
+				$speed = $sspeed;
+			}
+		}
+#		print "ethlines: $ethlines\n";
+	}
+}
+
+if ($speed == 0) {
+	print "Could not find supported link modes for interface $if. No speed defined with -s either.\n"; exit 2;
+}
+
+$speedok = 0;
+if ($opt_m) {
+	if ($modes{"speed"} >= $speed) {
+		$speedok = 1;
+	}
+	$speedtxt = "minimum";
+} else {
+	if ($modes{"speed"} eq $speed) {
+		$speedok = 1;
+	}
+	$speedtxt = "exact";
+	
+}
+
+# Do not care about autoneg if it is not supported
+if ($modes{"supports_auto-negotiation"} eq "no") {
+	$opt_a = "ignored";
+}
+
+if ($speedok == 0 || $opt_d ne $modes{"duplex"} || ($opt_a ne "ignored" && $opt_a ne $modes{"autoneg"})) {
+	print "Media settings error on $if. Expected $speed ($speedtxt) $opt_d autoneg=$opt_a, got " . $modes{"speed"} . " " . $modes{"duplex"} . " " . $modes{"autoneg"} . "\n";
+	exit(2);
+} else {
+	print "Media settings OK on $if " . $modes{"speed"} . " ($speedtxt match with $speed) " . $modes{"duplex"} . " autoneg=" . $modes{"autoneg"};
+	if ($opt_a eq "ignored") {
+		print " (autoneg ignored)";
+	}
+	print "\n";
+	exit(0);
+}

--- a/ansible/roles/monitoring_agent/files/plugins/check_ping.sh
+++ b/ansible/roles/monitoring_agent/files/plugins/check_ping.sh
@@ -61,8 +61,8 @@ warn_pct=$(printf %.0f $pct)
 output=$(mktemp)
 /bin/$pingcmd -c $packets -w $crit_sec $host > $output
 ret=$?
-status=$(egrep 'transmitted|round-trip|rtt' $output)
-rta=$(egrep 'round-trip|rtt' $output |cut -d= -f 2|cut -d / -f 2)
+status=$(grep -E 'transmitted|round-trip|rtt' $output)
+rta=$(grep -E 'round-trip|rtt' $output |cut -d= -f 2|cut -d / -f 2)
 loss=$(echo $status | grep -oP '[0-9]{1,3}%'|cut -d% -f 1)
 rm $output
 if [ $ret != 0 ]; then

--- a/ansible/roles/monitoring_agent/tasks/packages.yml
+++ b/ansible/roles/monitoring_agent/tasks/packages.yml
@@ -41,3 +41,10 @@
   command: pip3 install --break-system-packages {{ pip_packages|join(' ') }}
   args:
     creates: /usr/local/lib/python3.12/dist-packages/mdstat
+  when: ansible_distribution_version >= '24.04'
+
+- name: Python packages for monitoring
+  command: pip3 install {{ pip_packages|join(' ') }}
+  args:
+    creates: /usr/local/lib/python3.10/dist-packages/mdstat
+  when: ansible_distribution_version < '24.04'

--- a/ansible/roles/network/defaults/main.yml
+++ b/ansible/roles/network/defaults/main.yml
@@ -70,7 +70,6 @@ netplan_bridged:
     bridges:
       br0:
         addresses: "{{ network.addresses }}"
-        gateway4: "{{ network.gateway }}"
         nameservers:
           search: "{{ ansible_dns.search }}"
           addresses: "{{ network.nameservers }}"

--- a/ansible/roles/network/tasks/netplan.yml
+++ b/ansible/roles/network/tasks/netplan.yml
@@ -35,4 +35,5 @@
   template:
     dest: /etc/netplan/01-netcfg.yaml
     src: netplan.j2
+    mode: 0600
   notify: Netplan apply

--- a/images/mysqldump/helm/values.yaml
+++ b/images/mysqldump/helm/values.yaml
@@ -4,6 +4,7 @@ deployment:
     hour: "5"
     servers: db00
     skew_seconds: "30"
+    skip_ssl: "true"
     tz: UTC
   nodeSelector:
     service.mysqldump: allow

--- a/images/mythtv-backend/helm/Chart.yaml
+++ b/images/mythtv-backend/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/mythtv/mythtv
 type: application
-version: 0.1.10
-appVersion: "33.1-fixes.202405301110.512d723c83"
+version: 0.1.11
+appVersion: "34.0-fixes.202501030536.ac34c663b2"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/mythtv-backend/helm/values.yaml
+++ b/images/mythtv-backend/helm/values.yaml
@@ -55,7 +55,7 @@ volumes:
 - name: ssh-config
   emptyDir: {}
 - name: data
-  hostPath: { path: $MYTHTV_VOL_PATH }
+  hostPath: { path: /var/mythtv }
 - name: videos
   persistentVolumeClaim:
     claimName: videos
@@ -132,6 +132,20 @@ data-sync:
       sync_interval: 240
     nodeSelector:
       service.mythtv-backend: allow
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - data-sync
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+              - mythtv-backend
+          topologyKey: kubernetes.io/hostname
     replicas: 2
     resources:
       limits:

--- a/images/nut-upsd/entrypoint.sh
+++ b/images/nut-upsd/entrypoint.sh
@@ -1,7 +1,5 @@
 #! /bin/sh -e
 
-cat /etc/passwd
-
 if [ -d /run/secrets ] && [ -s /run/secrets/$SECRETNAME ]; then
   API_PASSWORD=$(cat /run/secrets/$SECRETNAME)
 fi

--- a/images/weewx/helm/values.yaml
+++ b/images/weewx/helm/values.yaml
@@ -1,7 +1,7 @@
 # Default values for weewx.
 deployment:
   env:
-    airlink_host: airlink
+    airlink_host: ""
     altitude: 100, foot
     computer_type: Linux x86_64 with Kubernetes
     db_host: db00

--- a/k8s/helm/guacamole/Chart.yaml
+++ b/k8s/helm/guacamole/Chart.yaml
@@ -8,14 +8,16 @@ sources:
 - https://github.com/apache/guacamole-server
 type: application
 version: 0.1.5
+# When updating appVersion, also update subcharts, and the dependencies
+#  for guacamole-server and guacd below
 appVersion: "1.5.5"
 dependencies:
 - name: chartlib
   version: 0.1.8
   repository: https://instantlinux.github.io/docker-tools
 - name: guacamole-server
-  version: 0.1.3
+  version: 0.1.4
   repository: file://subcharts/guacamole-server
 - name: guacd
-  version: 0.1.3
+  version: 0.1.4
   repository: file://subcharts/guacd

--- a/k8s/helm/restic/Chart.yaml
+++ b/k8s/helm/restic/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/restic/restic
 type: application
-version: 0.1.12
+version: 0.1.13
 # Remember to update restic==<ver> in values.yaml as releases are published;
 #  the values.yaml file is not able to reference .Chart.appVersion
 appVersion: "0.17.3-r0"

--- a/k8s/helm/restic/values.yaml
+++ b/k8s/helm/restic/values.yaml
@@ -94,8 +94,7 @@ volumes:
 image:
   repository: alpine
   pullPolicy: IfNotPresent
-  # tag: 3.20
-  tag: latest
+  tag: 3.21
 
 nameOverride: ""
 fullnameOverride: ""

--- a/k8s/install/k8s-backup.yaml
+++ b/k8s/install/k8s-backup.yaml
@@ -14,7 +14,7 @@ spec:
           containers:
           - name: backup
             # Same image as in /etc/kubernetes/manifests/etcd.yaml
-            image: registry.k8s.io/etcd:3.5.4-0
+            image: registry.k8s.io/etcd:3.5.15-0
             command: ["/bin/sh"]
             args: ["-c", "etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key snapshot save /backup/etcd-snapshot-$(printf '%(%y-%m-%d_%T)T').db"]
             env:


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
This is a cleanup of minor issues since security-patching a month ago.

* ansible: Adjust default docker version 
* ansible: add check_ethtool nagios script
* ansible: adjust check_ping.sh to use grep instead of egrep (alpine 3.21)
* ansible: remove gateway4 reference from netplan (ubuntu 24.04)
* helm: expose skip-ssl param in mysqldump
* helm: mythtv-backend version
* helm: update subchart version dependencies in guacamole
* helm: restic version
* nut-upsd: remove debug statement in entrypoint
* k8s infra: use newer etcd for backup cron job

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

Routine update to handle deprecated syntax and versions under newest alpine and ubuntu.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing and CI.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
