### PR TITLE
SYS-638 fix weewx startup, add antiAffinity to a few charts

### DIFF
--- a/images/dhcpd-dns-pxe/helm/Chart.yaml
+++ b/images/dhcpd-dns-pxe/helm/Chart.yaml
@@ -7,7 +7,7 @@ sources:
 - https://source.isc.org/git/dhcp.git
 - http://thekelleys.org.uk/gitweb/?p=dnsmasq.git
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "4.4.3_p1-r4-2.90-r3"
 dependencies:
 - name: chartlib

--- a/images/dhcpd-dns-pxe/helm/values.yaml
+++ b/images/dhcpd-dns-pxe/helm/values.yaml
@@ -26,6 +26,15 @@ statefulset:
     capabilities:
       add: [ NET_ADMIN ]
   replicas: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values: [ dhcpd-dns-pxe ]
+        topologyKey: kubernetes.io/hostname
 volumeMounts:
 - mountPath: /tftpboot/pxelinux
   name: share

--- a/images/dovecot/helm/Chart.yaml
+++ b/images/dovecot/helm/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/vdukhovni/dovecot
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "2.3.21.1-r0"
 dependencies:
 - name: chartlib

--- a/images/dovecot/helm/values.yaml
+++ b/images/dovecot/helm/values.yaml
@@ -195,6 +195,18 @@ data-sync:
       sync_interval: 2
     nodeSelector:
       service.dovecot: allow
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values: [ data-sync ]
+            - key: app.kubernetes.io/instance
+              operator: In
+              values: [ dovecot ]
+          topologyKey: kubernetes.io/hostname
     replicas: 3
     resources:
       limits:

--- a/images/postfix-python/helm/Chart.yaml
+++ b/images/postfix-python/helm/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/vdukhovni/postfix
 type: application
-version: 0.1.15
+version: 0.1.16
 appVersion: "3.9.1-r0"
 dependencies:
 - name: chartlib

--- a/images/postfix-python/helm/values.yaml
+++ b/images/postfix-python/helm/values.yaml
@@ -101,6 +101,15 @@ statefulset:
   - containerPort: 25
   - containerPort: 3525
   replicas: 2
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values: [ postfix ]
+        topologyKey: kubernetes.io/hostname
 volumeMounts:
 - mountPath: /etc/postfix/postfix.d
   name: config

--- a/images/weewx/Dockerfile
+++ b/images/weewx/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.20
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
+    org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.license=GPL-3.0 \
     org.label-schema.name=weewx \
     org.label-schema.vcs-ref=$VCS_REF \

--- a/images/weewx/README.md
+++ b/images/weewx/README.md
@@ -25,7 +25,7 @@ definition, or (even easier) under Kubernetes deploy the
 
 | Variable | Default value | Description |
 | -------- | ------------- | ----------- |
-| AIRLINK_HOST | | local hostname or IP of AirLink AQI sensor|
+| AIRLINK_HOST | | local hostname or IP of AirLink AQI sensor, if installed|
 | ALTITUDE | "100, foot" | elevation of station |
 | LATITUDE | 50.00 | coordinates |
 | LONGITUDE | -80.00 | coordinates  |

--- a/images/weewx/entrypoint.sh
+++ b/images/weewx/entrypoint.sh
@@ -70,7 +70,7 @@ if [ ! -e $WX_ROOT/weewx.conf.bak ]; then
     sed -i -e "s/hostname = airlink$/hostname = $AIRLINK_HOST/" \
       $WX_ROOT/weewx.conf
   else
-    sed -i "/[[Sensor1]]/{n;s/.*/        enable = false/}" $WX_ROOT/weewx.conf
+    su $WX_USER -c "weectl extension uninstall --yes airlink"
   fi
   if [ $SKIN != Season ]; then
     sed -i \

--- a/k8s/helm/etcd/Chart.yaml
+++ b/k8s/helm/etcd/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/etcd-io/etcd
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "v3.5.6"
 dependencies:
 - name: chartlib

--- a/k8s/helm/etcd/values.yaml
+++ b/k8s/helm/etcd/values.yaml
@@ -47,6 +47,18 @@ statefulset:
     etcd_listen_client_urls: "http://0.0.0.0:2379"
     etcd_listen_peer_urls: "http://0.0.0.0:2380"
   hostNetwork: true
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values: [ etcd ]
+          - key: app.kubernetes.io/instance
+            operator: In
+            values: [ etcd ]
+        topologyKey: kubernetes.io/hostname
   replicas: 3
 volumeMounts:
 - mountPath: /var/lib/etcd


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Fix weewx entrypoint so it doesn't crash on startup if airlink host isn't specified
* Add podAntiAffinity to several helm charts so all pods and volumes are assigned to different k8s workers
## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
The weewx image was broken since airlink was added.
There were several statefulsets that would come up improperly if count of available workers at initial startup was less than specified replica count.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
CI and local testing

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
