### PR TITLE
SYS-642 minio and restic fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The cluster-deployment tools here include helm charts and ansible playbooks to s
 * Calico or flannel networking
 * ingress-nginx
 * Local-volume sync
-* Minio object storage
+* Minio object storage with prometheus metrics
 * Pod security policies
 * Automatic certificate issuing/renewal with Letsencrypt
 * PostgreSQL-operator from CrunchyData

--- a/ansible/roles/docker_node/tasks/docker.yml
+++ b/ansible/roles/docker_node/tasks/docker.yml
@@ -142,19 +142,14 @@
     enabled: yes
     name: docker-permissions
 
-- name: Download docker-compose
+- name: Download docker-compose (deprecated since V2 release)
   ansible.builtin.get_url:
     checksum: sha256:{{ docker.compose.sha256 }}
     dest: /usr/local/bin/docker-compose
     mode: 0755
     url: https://github.com/docker/compose/releases/download/{{
       docker.compose.version }}/docker-compose-Linux-x86_64
-  when: ansible_distribution_version < '24.04'
-
-- name: Install docker-compose from repo
-  ansible.builtin.apt:
-    name: docker-compose
-  when: ansible_distribution_version >= '24.04'
+  when: ansible_distribution_version < '22.04'
 
 - name: Sysctl tuning parameters
   ansible.builtin.sysctl:

--- a/ansible/roles/fileserver/defaults/main.yml
+++ b/ansible/roles/fileserver/defaults/main.yml
@@ -28,7 +28,7 @@ ubuntu_packages:
   - unison
   - vsftpd
 
-virtualbox:
+virtualbox_defaults:
   enabled: true
   apt_repo:
     url: http://download.virtualbox.org/virtualbox/debian
@@ -36,6 +36,9 @@ virtualbox:
     - https://www.virtualbox.org/download/oracle_vbox_2016.asc
     - https://www.virtualbox.org/download/oracle_vbox.asc
   version: 7.1
+
+virtualbox_override: {}
+virtualbox: "{{ virtualbox_defaults | combine(virtualbox_override) }}"
 
 vsftpd:
   enabled: true

--- a/ansible/roles/fileserver/tasks/main.yml
+++ b/ansible/roles/fileserver/tasks/main.yml
@@ -17,13 +17,48 @@
 - import_tasks: nfs.yml
   when: nfs_exports
 
+- name: Disable nfs-server
+  systemd:
+    name: nfs-server
+    state: stopped
+    enabled: no
+  when: not nfs_exports
+
+- name: Disable rpcbind if no network volumes
+  systemd:
+    name: rpcbind
+    state: stopped
+    enabled: no
+  when: not nfs_exports
+
 - import_tasks: instantlinux.yml
 
 - import_tasks: samba.yml
   when: samba.enabled
+
+- name: Disable smbd service
+  systemd:
+    name: smbd
+    state: stopped
+    enabled: no
+  when: not samba.enabled
+
+- name: Disable nmbd service
+  systemd:
+    name: nmbd
+    state: stopped
+    enabled: no
+  when: not samba.enabled
 
 - import_tasks: virtualbox.yml
   when: virtualbox.enabled
 
 - import_tasks: vsftpd.yml
   when: vsftpd.enabled
+
+- name: Disable vsftpd service
+  systemd:
+    name: vsftpd
+    state: stopped
+    enabled: no
+  when: not vsftpd.enabled

--- a/k8s/helm/restic/Chart.yaml
+++ b/k8s/helm/restic/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/restic/restic
 type: application
-version: 0.1.14
+version: 0.1.15
 # Remember to update restic==<ver> in values.yaml as releases are published;
 #  the values.yaml file is not able to reference .Chart.appVersion
 appVersion: "0.17.3-r2"

--- a/k8s/helm/restic/values.yaml
+++ b/k8s/helm/restic/values.yaml
@@ -7,9 +7,10 @@ deployment:
   args:
   - -c
   - >
-    apk add --update restic==$APP_VERSION tzdata &&
+    apk add --update restic==$APP_VERSION ca-certificates tzdata &&
     ln -s /usr/share/zoneinfo/$TZ /etc/localtime &&
     echo $TZ > /etc/timezone &&
+    update-ca-certificates &&
     echo "if [ -r $HOME/.resticrc ]; then . $HOME/.resticrc; fi" \
       >>/etc/profile.d/restic.sh &&
     touch /var/log/restic.log && /usr/sbin/crond &&
@@ -40,6 +41,9 @@ volumeMounts:
 - mountPath: /bin/set-key.sh
   name: config
   subPath: set-key.sh
+- mountPath: /usr/local/share/ca-certificates/ca-root.crt
+  name: config
+  subPath: ca-root.crt
 - mountPath: /root/.cache/restic
   name: cache
 
@@ -122,6 +126,9 @@ configmap:
       export REPO_LOCAL=rest:http://bkp:$REPO_LOCAL_PASSWORD@k2.ci.net:8000
       export RESTIC_PROGRESS_FPS=1
       export RETAIN_SCHED="forget --keep-daily 7 --keep-weekly 5 --keep-monthly 12 --keep-yearly 75"
+
+    ca-root.crt: |
+      # Add to your overrides if using a private CA root
 
     cron: |
       # Customize as desired

--- a/k8s/volumes/backup-ios.yaml
+++ b/k8s/volumes/backup-ios.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: backup-ios
+  labels:
+    volume.group: backup-ios
+spec:
+  capacity:
+    storage: 1Mi 
+  accessModes:
+    - ReadWriteMany 
+  persistentVolumeReclaimPolicy: Retain 
+  nfs: 
+    path: /var/backup/ios
+    server: $NFS_HOST
+  storageClassName: nfs-client
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backup-ios
+  namespace: $K8S_NAMESPACE
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+     requests:
+       storage: 1Mi
+  selector:
+    matchLabels:
+      volume.group: backup-ios
+  storageClassName: nfs-client

--- a/services/minio/docker-compose.yml
+++ b/services/minio/docker-compose.yml
@@ -3,21 +3,63 @@ services:
     image: quay.io/minio/minio:${VERSION_MINIO:-latest}
     command: >
       server /data/vol{1...${MINIO_VOL_COUNT:-4}}/
-       --console-address ":9001"
+       --address "0.0.0.0:9000"
+       --console-address "0.0.0.0:9001"
+       --certs-dir /opt/certs
     environment:
-      MINIO_ROOT_USER:     ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-      MINIO_GID:           ${MINIO_GID:-1000}
-      MINIO_UID:           ${MINIO_UID:-1000}
-      MINIO_GROUPNAME:     ${MINIO_GROUPNAME:-minio}
-      MINIO_USERNAME:      ${MINIO_USERNAME:-minio}
+      MINIO_ROOT_USER_FILE:     /run/secrets/minio-root-user
+      MINIO_ROOT_PASSWORD_FILE: /run/secrets/minio-root-password
+      MINIO_GID:                ${MINIO_GID:-1000}
+      MINIO_UID:                ${MINIO_UID:-1000}
+      MINIO_GROUPNAME:          ${MINIO_GROUPNAME:-minio}
+      MINIO_USERNAME:           ${MINIO_USERNAME:-minio}
+      MINIO_PROMETHEUS_URL:     ${MINIO_PROMETHEUS_URL:-http://prometheus:9090}
     ports:
     - ${PORT_MINIO_API:-9000}:9000
     - ${PORT_MINIO_CONSOLE:-9001}:9001
     restart: always
+    secrets:
+    - minio-root-user
+    - minio-root-password
     volumes:
     - ${MINIO_ROOT:-/data}:/data
-    - ${MINIO_CERTS_DIR:-~/ssl/minio}:/root/.minio/certs
+    - ${MINIO_CERTS_DIR:-~/ssl/minio}:/opt/certs
+  prometheus:
+    image: prom/prometheus:latest
+    command: --config.file=/etc/prometheus/prometheus.yml
+    configs:
+    - source: prometheus.yml
+      target: /etc/prometheus/prometheus.yml
+    ports:
+    - "9090:9090"
+    secrets:
+    - minio-bearer-token
+    volumes:
+    - prometheus-data:/prometheus
+    - ${MINIO_CERTS_DIR:-~/ssl/minio}:/opt/certs
+secrets:
+  minio-bearer-token:
+    file: /var/adm/secrets/minio-bearer-token
+  minio-root-user:
+    file: /var/adm/secrets/minio-root-user
+  minio-root-password:
+    file: /var/adm/secrets/minio-root-password
 volumes:
   data:
     driver: local
+  prometheus-data:
+configs:
+  prometheus.yml:
+    content: |
+      global:
+        scrape_interval: 2s
+        evaluation_interval: 2s
+      scrape_configs:
+      - job_name: minio-job
+        bearer_token_file: /run/secrets/minio-bearer-token
+        metrics_path: /minio/v2/metrics/cluster
+        scheme: https
+        static_configs:
+        - targets: ['${MINIO_FQDN:-localhost}:${PORT_MINIO_API:-9000}']
+        tls_config:
+          ca_file: /opt/certs/CAs/ca-root.crt


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Deprecated docker-compose phased out (replaced by `docker compose`) from ansible
* Fixed all references to disabled services (nfs, samba, virtualbox, vsftpd)
* Add local ca-root cert support to restic helm chart
* Add prometheus metrics to minio

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

Issues with ansible for minio-centric fileserver; can now run minio with TLS and performance metrics.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
