### PR TITLE
Issue #189 retire DSA keys from proftpd image

### DIFF
--- a/images/proftpd/Dockerfile
+++ b/images/proftpd/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ARG PROFTPD_VERSION=1.3.8c-r0
+ARG PROFTPD_VERSION=1.3.8d-r0
 
 ENV ALLOW_OVERWRITE=on \
     ANONYMOUS_DISABLE=off \

--- a/images/proftpd/entrypoint.sh
+++ b/images/proftpd/entrypoint.sh
@@ -21,7 +21,6 @@ fi
 if [ "$SFTP_ENABLE" = "on" ]; then
   mkdir -p /etc/ssh
   test -f /etc/ssh/ssh_host_rsa_key   || ssh-keygen -m PEM -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa -b 2048
-  test -f /etc/ssh/ssh_host_dsa_key   || ssh-keygen -m PEM -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa -b 1024
   test -f /etc/ssh/ssh_host_ecdsa_key || ssh-keygen -m PEM -f /etc/ssh/ssh_host_ecdsa_key -N '' -t ecdsa -b 521
 
   sed -i -e "/^Port/s/^/#/" /etc/proftpd/proftpd.conf

--- a/images/proftpd/helm/Chart.yaml
+++ b/images/proftpd/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/proftpd/proftpd
 type: application
-version: 0.1.10
-appVersion: "1.3.8c-r0"
+version: 0.1.11
+appVersion: "1.3.8d-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Bump proftpd version to `1.3.8d-r0`, and remove DSA key generation.

## Why is this change being made?
As noted by @grosbedos:

> The proftpd image with sftp enabled no longer starts. I think openssh no longer supports DSA keys by default.

## How was this tested? How can the reviewer verify your testing?

Local testing and CI.

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
