### PR TITLE
SYS-647 updates - haproxy-keepalived, spamassassin, udp-nginx-proxy

### DIFF
--- a/.image-gitlab-ci.yml
+++ b/.image-gitlab-ci.yml
@@ -48,9 +48,16 @@ security_scan_trivy:
     TRIVY_DEBUG: "true"
     TRIVY_EXIT_CODE: 1
     TRIVY_FORMAT: json
+    TRIVY_IGNORE: >-
+      "CVE-2023-31484,CVE-2023-45853,
+      CVE-2023-52425,CVE-2024-8176"
+      # These are for blacklist image, there's a won't-fix note for zlib1g
+      # CVE-2023-31484,CVE-2023-45853
+      # These are for spamassassin under debian bookworm
+      # CVE-2023-52425,CVE-2024-8176
     TRIVY_OUTPUT: gl-container-scanning-report.json
     TRIVY_SEVERITY: HIGH,CRITICAL
-    TRIVY_VULN_TYPE: os,library
+    TRIVY_PKG_TYPES: os,library
   script:
   - export TAG=bld_$CI_PIPELINE_IID_${CI_COMMIT_SHORT_SHA}
   - trivy clean --all
@@ -58,12 +65,7 @@ security_scan_trivy:
   - trivy image "${REGISTRY}/${IMAGE}:${TAG}" --severity LOW,MEDIUM
       --exit-code 0 --format table --output medium-vulns.txt
   - cat medium-vulns.txt
-  - echo CVE-2023-2253 > .trivyignore
-  # These are for blacklist image, there's a won't-fix note for zlib1g
-  - echo CVE-2023-31484 >> .trivyignore
-  - echo CVE-2023-45853 >> .trivyignore
-  # TODO remove this openssh bypass once repo is updated
-  - echo CVE-2024-6387 >> .trivyignore
+  - echo $TRIVY_IGNORE | tr , "\n" > .trivyignore
   - trivy image "${REGISTRY}/${IMAGE}:${TAG}"
   cache:
     paths: [ .trivycache ]

--- a/images/haproxy-keepalived/Dockerfile
+++ b/images/haproxy-keepalived/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:3.1.2-alpine
+FROM haproxy:3.1.6-alpine
 ARG BUILD_DATE
 ARG VCS_REF
 LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \

--- a/images/spamassassin/Dockerfile
+++ b/images/spamassassin/Dockerfile
@@ -41,8 +41,8 @@ RUN apt-get -yq update && apt-get -y upgrade && \
      /etc/razor/razor-agent.conf && \
     sed -i 's/DCCIFD_ENABLE=off/DCCIFD_ENABLE=on/' /var/dcc/dcc_conf && \
     sed -i '/^#\s*loadplugin .\+::DCC/s/^#\s*//g' /etc/spamassassin/v310.pre && \
-    apt-get purge -yq binutils cpp-11 libc6-dev libgcc-11-dev \
-     linux-libc-dev make && \
+    apt-get purge -yq binutils libldap-2.5-0 linux-libc-dev make && \
+    apt-get -yq autoremove && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/log/*
 
 COPY entrypoint.sh /root/

--- a/images/spamassassin/helm/values.yaml
+++ b/images/spamassassin/helm/values.yaml
@@ -38,7 +38,9 @@ volumeClaimTemplates:
         storage: 50Mi
 
 image:
-  repository: instantlinux/spamassassin
+  # repository: instantlinux/spamassassin
+  repository: nexus.instantlinux.net/spamassassin
+  tag: testing
   pullPolicy: IfNotPresent
   # tag: default
 

--- a/images/udp-nginx-proxy/Dockerfile
+++ b/images/udp-nginx-proxy/Dockerfile
@@ -14,7 +14,9 @@ ENV BACKENDS=self \
     PORT_BACKEND=53 \
     PORT_LISTEN=53
 
-RUN rm /etc/nginx/conf.d/default.conf
+RUN apk --update --no-cache upgrade && \
+    rm /etc/nginx/conf.d/default.conf
+
 EXPOSE 53
 VOLUME /usr/local/lib
 COPY entrypoint.sh /usr/local/bin/

--- a/lib/build/Makefile.docker_image
+++ b/lib/build/Makefile.docker_image
@@ -61,18 +61,9 @@ promote_image: $(HOME)/.docker/cli-plugins/docker-buildx
 	  --build-arg=BUILD_DATE=$(shell date +%Y-%m-%dT%H:%M:%SZ)
 	-if [ -x hooks/post_build ]; then sh hooks/post_build; fi
 
-	# TODO - this only pushes amd64 manifest; as of May 2020 it seems
-	#  that only "docker buildx create --push" handles multi-platform
-	#  this slows down pipeline big-time
-	# docker pull $(REGISTRY)/$(IMAGE):$(TAG)
-	# docker tag $(REGISTRY)/$(IMAGE):$(TAG) $(REGISTRY)/$(IMAGE):latest
-	# docker push $(REGISTRY)/$(IMAGE):latest
-	# docker tag $(REGISTRY)/$(IMAGE):$(TAG) $(USER_LOGIN)/$(IMAGE):$(TAG)
-	# docker tag $(REGISTRY)/$(IMAGE):$(TAG) $(USER_LOGIN)/$(IMAGE):latest
-	# docker push $(USER_LOGIN)/$(IMAGE):$(TAG)
-	# docker push $(USER_LOGIN)/$(IMAGE):latest
 	# TODO update dockerhub README if/when that is supported,
 	# see https://github.com/docker/hub-feedback/issues/1927
+	# and https://github.com/docker/hub-feedback/issues/2127
 
 flake8: test_requirements
 	@echo "Running flake8 code analysis"


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Update haproxy-keepalived, improve builds for spamassassin and udp-nginx-proxy

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Vulnerability updates. The spamassassin image uses debian:bookworm, for which two CVEs were mitigated in a way that the trivy scanner doesn't respect. The nginx image likewise had a couple of CVEs which are mitigated in packages that came out after the tag `1.27.4-alpine` was built.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

This is _not_ fully tested prior to merge: the change to .image-gitlab-ci.yml will trigger builds of all images, maxing out monthly minutes of gitlab executor quota (only want to do this once).
## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
