### PR TITLE
SYS-648 k8sudo script to lock down k8s admin.conf

### DIFF
--- a/ansible/roles/monitoring_agent/files/plugins/check-file-exists
+++ b/ansible/roles/monitoring_agent/files/plugins/check-file-exists
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# https://github.com/dnmvisser/nagios-check-file-exists
+import argparse
+import sys
+import os
+import textwrap
+
+def nagios_exit(message, code):
+    print(message)
+    sys.exit(code)
+
+try:
+    parser = argparse.ArgumentParser(
+            description='Check for the (non) existence of a file',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=textwrap.dedent('''\
+                To check for pending reboots on Debian/Ubuntu:
+
+                %(prog)s -f /var/run/reboot-required --absent
+            '''))
+
+    parser.add_argument('-f', '--file',
+            dest='path',
+            help='file to check',
+            required=True)
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--present',
+            default=True,
+            dest='status',
+            help='return OK if file exists, and WARNING or CRITICAL if file does not exist',
+            action='store_true')
+    group.add_argument('--absent',
+            default=False,
+            dest='status',
+            help='return OK if file does not exist, and WARNING or CRITICAL if it exists',
+            action='store_false')
+
+    group2 = parser.add_mutually_exclusive_group()
+    group2.add_argument('--warning', '-w',
+            default='warn',
+            dest='severity',
+            help='Upon failure, return WARNING',
+            action='store_const',
+            const='warn')
+    group2.add_argument('--critical', '-c',
+            dest='severity',
+            help='Upon failure, return CRITICAL',
+            action='store_const',
+            const='crit')
+
+    args = parser.parse_args()
+
+    path = args.path
+    status = args.status
+    severity = args.severity
+
+    # start with clean slate
+    ok_msg = []
+    warn_msg = []
+    crit_msg = []
+
+    found = os.path.isfile(path)
+
+    msg = "File " + path + " " + ("" if found else "not ") + "found"
+
+    if(found == status):
+        ok_msg.append(msg)
+    else:
+        if(severity == 'warn'):
+            warn_msg.append(msg)
+        else:
+            crit_msg.append(msg)
+
+except Exception as e:
+  nagios_exit("UNKNOWN: Unknown error: {0}.".format(e), 3)
+
+# Exit with accumulated message(s)
+if crit_msg:
+    nagios_exit("CRITICAL: " + ' '.join(crit_msg + warn_msg), 2)
+elif warn_msg:
+    nagios_exit("WARNING: " + ' '.join(warn_msg), 1)
+else:
+    nagios_exit("OK: " + ' '.join(ok_msg), 0)

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -26,7 +26,8 @@ kubeadm suite:
 * Non-default namespace with its own service account (full permissions
   within namespace, limited read-only in kube-system namespaces)
 * Helm
-* Keycloak
+* Keycloak for login auth to kube-apiserver
+* A k8sudo script to encrypt/decrypt k8s admin key
 * Mozilla [sops](https://github.com/mozilla/sops/blob/master/README.rst) with encryption (to keep credentials in local git repo)
 * Encryption for internal etcd
 * MFA using [Authelia](https://github.com/clems4ever/authelia) and Google Authenticator

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -307,6 +307,10 @@ I've tried several different approaches to keeping volumes in sync; the most pop
 
 Explore this repo for several different approaches to data backups. Restic is the main off-the-shelf tool that I've found as an alternative to CrashPlan for Home. Another tool called Duplicati works well for small savesets (it chokes on larger ones and doesn't generate log output for monitoring). My [secondshot](https://github.com/instantlinux/secondshot)_ tool adds metadata-indexing and monitoring to the _rsnapshot_ method.
 
+### k8sudo with k8lock
+
+Keeping an unencrypted copy of the key from admin.conf is a security risk. This script provides a convenient toggle mechanism to raise and drop privileges using openssl `aes-256-cbc` on the infrequent occasions when this key is needed. See the script at [scripts/k8sudo](https://github.com/instantlinux/docker-tools/blob/main/k8s/scripts/k8sudo) for usage instructions.
+
 ### Additional notes
 
 I've run into a ton of issues, minor and major, setting up Kubernetes on

--- a/k8s/scripts/k8sudo
+++ b/k8s/scripts/k8sudo
@@ -1,37 +1,5 @@
 #! /bin/sh -e
 # This script encrypts the admin key used for kubectl --context=sudo
-# Add two aliases and the admin keyfile name to .bashrc:
-#  alias k8lock="~/docker/k8s/scripts/k8sudo lock"
-#  alias k8sudo="~/docker/k8s/scripts/k8sudo sudo"
-#  export ADMIN_KEY=~/.kube/myadmin.key
-#
-# Make sure your .kube/config.conf omits the admin client key material
-#  and references it thus:
-#
-#    users:
-#    - name: my-admin
-#      user:
-#        client-certificate: myadmin.crt
-#        client-key: myadmin.key
-#    contexts:
-#    - context:
-#        cluster: mycluster
-#        namespace: kube-system
-#        user: my-admin
-#        name: sudo
-#
-# A check-file-exists Nagios NRPE script (credit: github.com/dnmvisser)
-#  is provided in ansible role 'monitoring'; to get a warning that the
-#  key is decrypted:
-#
-# * define a service K8SUDO as 'check_nrpe -c check_k8sudo'
-# * add this nrpe_command_override entry to the host's ansible
-#   definition:
-#
-#    k8sudo:
-#      local: True
-#      plugin: check-file-exists
-#      options: --absent -w -f /tmp/.k8sadm.txt
 
 CMD=$1
 [ -z "$ADMIN_KEY" ] && ADMIN_KEY=~/.kube/admin-user.key
@@ -53,6 +21,48 @@ elif [ $CMD = lock ]; then
      echo "** Nothing to do **"
      rm -f $ADMIN_KEY
    fi
+elif [ $CMD = "--help" ]; then
+    cat <<EOF
+Usage:
+  k8sudo sudo  -- to decrypt
+  k8sudo lock  -- to drop privilage
+
+Setup:
+
+Add two aliases and the admin keyfile name to .bashrc:
+ alias k8lock="~/docker/k8s/scripts/k8sudo lock"
+ alias k8sudo="~/docker/k8s/scripts/k8sudo sudo"
+ export ADMIN_KEY=~/.kube/myadmin.key
+
+Make sure your .kube/config.conf omits the admin client key material
+ and references it thus:
+
+   users:
+   - name: my-admin
+     user:
+       client-certificate: myadmin.crt
+       client-key: myadmin.key
+   contexts:
+   - context:
+       cluster: mycluster
+       namespace: kube-system
+       user: my-admin
+       name: sudo
+
+A check-file-exists Nagios NRPE script (credit: github.com/dnmvisser)
+ is provided in ansible role 'monitoring'; to get a reminder to drop
+ privileges with k8lock after an admin session:
+
+* define a service K8SUDO as 'check_nrpe -c check_k8sudo'
+* add this nrpe_command_override entry to the host's ansible
+  definition:
+
+   k8sudo:
+     local: True
+     plugin: check-file-exists
+     options: --absent -w -f /tmp/.k8sadm.txt
+
+EOF
 else
-  Unrecognized - $CMD
+  echo $CMD unrecognized, see --help
 fi

--- a/k8s/scripts/k8sudo
+++ b/k8s/scripts/k8sudo
@@ -1,0 +1,58 @@
+#! /bin/sh -e
+# This script encrypts the admin key used for kubectl --context=sudo
+# Add two aliases and the admin keyfile name to .bashrc:
+#  alias k8lock="~/docker/k8s/scripts/k8sudo lock"
+#  alias k8sudo="~/docker/k8s/scripts/k8sudo sudo"
+#  export ADMIN_KEY=~/.kube/myadmin.key
+#
+# Make sure your .kube/config.conf omits the admin client key material
+#  and references it thus:
+#
+#    users:
+#    - name: my-admin
+#      user:
+#        client-certificate: myadmin.crt
+#        client-key: myadmin.key
+#    contexts:
+#    - context:
+#        cluster: mycluster
+#        namespace: kube-system
+#        user: my-admin
+#        name: sudo
+#
+# A check-file-exists Nagios NRPE script (credit: github.com/dnmvisser)
+#  is provided in ansible role 'monitoring'; to get a warning that the
+#  key is decrypted:
+#
+# * define a service K8SUDO as 'check_nrpe -c check_k8sudo'
+# * add this nrpe_command_override entry to the host's ansible
+#   definition:
+#
+#    k8sudo:
+#      local: True
+#      plugin: check-file-exists
+#      options: --absent -w -f /tmp/.k8sadm.txt
+
+CMD=$1
+[ -z "$ADMIN_KEY" ] && ADMIN_KEY=~/.kube/admin-user.key
+umask 077
+if [ $CMD = sudo ]; then
+ openssl enc -d -pbkdf2 -md md5 -aes-256-cbc \
+   -out $ADMIN_KEY -in ${ADMIN_KEY}.enc
+ date > /tmp/.k8sadm.txt
+elif [ $CMD = lock ]; then
+ if [ ! -f ${ADMIN_KEY}.enc ]; then
+   openssl enc -e -pbkdf2 -md md5 -aes-256-cbc -salt \
+     -in $ADMIN_KEY -out ${ADMIN_KEY}.enc
+   fi
+   if [ -s /tmp/.k8sadm.txt ]; then
+     rm $ADMIN_KEY
+     rm /tmp/.k8sadm.txt
+     echo "** Privileges dropped **"
+   else
+     echo "** Nothing to do **"
+     rm -f $ADMIN_KEY
+   fi
+else
+  Unrecognized - $CMD
+fi


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Adds a script `k8sudo` to k8s/scripts, which encrypts the key for admin.conf; also provides a nagios checker to avoid forgetting to invoke `k8lock`.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
The admin.conf key is occasionally required for emergency work. There's not really any convenient way to store it with encryption-at-rest.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Manual testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
