### PR TITLE
SYS-647 security update for nagiosql, add milter to spamassassin

### DIFF
--- a/.image-gitlab-ci.yml
+++ b/.image-gitlab-ci.yml
@@ -65,7 +65,7 @@ security_scan_trivy:
   - trivy image "${REGISTRY}/${IMAGE}:${TAG}" --severity LOW,MEDIUM
       --exit-code 0 --format table --output medium-vulns.txt
   - cat medium-vulns.txt
-  - echo $TRIVY_IGNORE | tr , "\n" | tee > .trivyignore
+  - echo $TRIVY_IGNORE | tr , "\n" | tee .trivyignore
   - trivy image "${REGISTRY}/${IMAGE}:${TAG}"
   cache:
     paths: [ .trivycache ]

--- a/images/nagiosql/Dockerfile
+++ b/images/nagiosql/Dockerfile
@@ -1,8 +1,7 @@
-FROM alpine:3.19
-MAINTAINER Rich Braun "docker@instantlinux.net"
+FROM alpine:3.21
 ARG BUILD_DATE
 ARG VCS_REF
-LABEL org.label-schema.build-date=$BUILD_DATE \
+LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.license=Apache-2.0 \
     org.label-schema.name=nagiosql \
     org.label-schema.vcs-ref=$VCS_REF \
@@ -12,7 +11,7 @@ ENV APACHE_BIN=httpd \
     APACHE_USER=apache \
     DB_HOST=db00 \
     DB_NAME=nagiosql \
-    DB_PASSWD_SECRET=nagiosql-db-password \
+    DB_SECRETNAME=nagiosql-db-password \
     DB_PORT=3306 \
     DB_USER=nagiosql \
     NAGIOS_ETC=/opt/nagios/etc \
@@ -21,23 +20,23 @@ ENV APACHE_BIN=httpd \
 ARG APACHE_UID=33
 ARG NAGIOS_GID=1000
 ARG NAGIOS_UID=999
-ARG NAGIOS_VERSION=4.4.13-r1
+ARG NAGIOS_VERSION=4.5.8-r0
 ARG NAGIOSQL_VERSION=3.5.0
 ARG NAGIOSQL_SHA=f777dfd8152768669ac73d96a6547fc5d8add80f50fb9fb4e255fc4f344d1222
 ARG NAGIOSQL_DOWNLOAD=nagiosql-$NAGIOSQL_VERSION-git2023-06-18.tar.bz2
 
 COPY src /tmp/
 COPY html /var/www/html
-RUN deluser xfs && addgroup -g $NAGIOS_GID nagios && \
+RUN addgroup -g $NAGIOS_GID nagios && \
     adduser -u $APACHE_UID -g Apache -DSH -h /var/www apache && \
     adduser -u $NAGIOS_UID -g "Nagios Server" -DSH -h /var/nagios nagios && \
-    apk add --update --no-cache apache2 curl nagios=$NAGIOS_VERSION php81 \
-      php81-apache2 php81-ftp php81-gettext php81-mysqli php81-pear php81-session \
-      php81-pecl-ssh2 tzdata && \
+    apk add --update --no-cache apache2 curl nagios=$NAGIOS_VERSION php82 \
+      php82-apache2 php82-ftp php82-gettext php82-mysqli php82-pear php82-session \
+      php82-pecl-ssh2 tzdata && \
     addgroup apache nagios && \
-    echo 'date.timezone = UTC' > /etc/php81/conf.d/50-tz.ini && \
+    echo 'date.timezone = UTC' > /etc/php82/conf.d/50-tz.ini && \
     echo 'include_path = ".:/var/www/nagiosql/libraries/pear"' \
-      > /etc/php81/conf.d/50-include.ini && \
+      > /etc/php82/conf.d/50-include.ini && \
     cd /tmp && \
     curl -sLo $NAGIOSQL_DOWNLOAD \
       https://sourceforge.net/projects/nagiosql/files/nagiosql/NagiosQL%20${NAGIOSQL_VERSION}/${NAGIOSQL_DOWNLOAD} && \

--- a/images/nagiosql/README.md
+++ b/images/nagiosql/README.md
@@ -36,7 +36,7 @@ DB_HOST | db00 | MySQL database hostname
 DB_NAME | nagiosql | database name
 DB_PORT | 3306 | TCP port number
 DB_USER | nagiosql | database username
-DB_PASSWD_SECRET | nagiosql-db-password | name of secret
+DB_SECRETNAME | nagiosql-db-password | name of secret
 DOMAIN | | used in docker-compose.yml by the nagios server
 NAGIOS_ETC | /opt/nagios/etc | volume mountpoint for nagios.cfg
 NAGIOS_MAIL_RELAY | smtp | DNS name for nagios email sending

--- a/images/nagiosql/entrypoint.sh
+++ b/images/nagiosql/entrypoint.sh
@@ -8,8 +8,8 @@ if [ ! -f /etc/timezone ] && [ ! -z "$TZ" ]; then
   echo $TZ >/etc/timezone
 fi
 
-if [ -e /run/secrets/$DB_PASSWD_SECRET ]; then
-  DB_PASS=$(cat /run/secrets/$DB_PASSWD_SECRET)
+if [ -e /run/secrets/$DB_SECRETNAME ]; then
+  DB_PASS=$(cat /run/secrets/$DB_SECRETNAME)
 fi
 
 if [ -s $NAGIOS_ETC/nagios.cfg ]; then

--- a/images/spamassassin/Dockerfile
+++ b/images/spamassassin/Dockerfile
@@ -23,8 +23,8 @@ ARG SPAMD_UID=2022
 RUN apt-get -yq update && apt-get -y upgrade && \
     apt-get -y --no-install-recommends install \
      ca-certificates cron curl gcc libc6-dev libdbd-mysql-perl \
-     libmail-dkim-perl libnet-ident-perl make pyzor razor gpg gpg-agent \
-     procps spamd=$SPAMD_VERSION && \
+     libmail-dkim-perl libmilter-dev libnet-ident-perl make pyzor razor \
+     gpg gpg-agent procps spamd=$SPAMD_VERSION && \
      usermod --uid $SPAMD_UID $USERNAME && \
      chsh -s /bin/sh $USERNAME && \
      mv /etc/mail/spamassassin/local.cf /etc/mail/spamassassin/local.cf-dist && \
@@ -41,7 +41,7 @@ RUN apt-get -yq update && apt-get -y upgrade && \
      /etc/razor/razor-agent.conf && \
     sed -i 's/DCCIFD_ENABLE=off/DCCIFD_ENABLE=on/' /var/dcc/dcc_conf && \
     sed -i '/^#\s*loadplugin .\+::DCC/s/^#\s*//g' /etc/spamassassin/v310.pre && \
-    apt-get purge -yq binutils libldap-2.5-0 linux-libc-dev make && \
+    apt-get purge -yq binutils libldap-2.5-0 linux-libc-dev libmilter-dev make && \
     apt-get -yq autoremove && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/log/*
 

--- a/images/spamassassin/helm/values.yaml
+++ b/images/spamassassin/helm/values.yaml
@@ -38,9 +38,7 @@ volumeClaimTemplates:
         storage: 50Mi
 
 image:
-  # repository: instantlinux/spamassassin
-  repository: nexus.instantlinux.net/spamassassin
-  tag: testing
+  repository: instantlinux/spamassassin
   pullPolicy: IfNotPresent
   # tag: default
 


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* nagiosql image updated from `3.5.0-4.4.13-r1` to `3.5.0-4.5.8-r0` under alpine:3.21
* libmilter added to spamassassin image

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Routine security patching, and eliminate this error in the spamassassin build:
```
*** cannot build dccm without milter header and library ***
```
## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing and CI.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
