### PR TITLE
Issue #189 - adjust proftpd to omit DSA key

### DIFF
--- a/images/proftpd/entrypoint.sh
+++ b/images/proftpd/entrypoint.sh
@@ -29,7 +29,8 @@ if [ "$SFTP_ENABLE" = "on" ]; then
       -e "s/^#\(  SFTPEngine on\)/\1/" \
       -e "s/^#\(  Port 2222.*\)/  Port $SFTP_PORT/" \
       -e "s/^#\(  SFTPCompression delayed\)/\1/" \
-      -e "s/^#\(  SFTPHostKey\)/\1/" \
+      -e "s/^#\(  SFTPHostKey .*ssh_host_rsa_key\)/\1/" \
+      -e "s/dsa_key/ssh_host_dsa_key (NO LONGER SUPPORTED)/" \
       /etc/proftpd/conf.d/sftp.conf
 fi
 


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Omit the DSA key from sftp.conf if `SFTP_ENABLE` is turned on.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
The upstream packager hasn't yet gotten rid of the now fully-deprecated `ssh_host_dsa_key` from the distributed /etc/proftpd/conf.d/sftp.conf. The entrypoint script here blindly enabled the now-incorrect key.

## How was this tested? How can the reviewer verify your testing?
Manual testing.

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
