### PR TITLE
SYS-641 mythtv image updated to 35.0

### DIFF
--- a/ansible/roles/mythfrontend/defaults/main.yml
+++ b/ansible/roles/mythfrontend/defaults/main.yml
@@ -227,7 +227,7 @@ ir_device:
 mythdb_overrides: {}
 db: "{{ db_defaults | combine(mythdb_overrides) }}"
 
-mythtv_version: 34
+mythtv_version: 35
 
 network_defaults:
   address: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"

--- a/images/mythtv-backend/Dockerfile
+++ b/images/mythtv-backend/Dockerfile
@@ -20,10 +20,8 @@ ENV APACHE_LOG_DIR=/var/log/apache2 \
 ARG APT_SIG=13551B881504888C
 ARG MYTHTV_GID=100
 ARG MYTHTV_UID=2021
-ARG MYTHTV_PPA=http://ppa.launchpad.net/mythbuntu/34
-ARG MYTHTV_VERSION=2:34.0+fixes.202502222320.d4f309f965~ubuntu24.04.1
-ARG SSH_PORT=2022
-ARG MYTHWEB_PORT=6760
+ARG MYTHTV_PPA=http://ppa.launchpad.net/mythbuntu/35
+ARG MYTHTV_VERSION=2:35.0+fixes.202504212209.eaa307f0b6~ubuntu24.04.1
 ARG PPA_BRANCH=33
 ARG MYTHLINK_SHA=459cb8b60adae4b631a95a9cfb1b41dcb959cc4a0b9053582a711d58b8d8a0d2
 
@@ -38,27 +36,21 @@ RUN \
   echo "# added via Dockerfile\npath-include=/usr/share/doc/mythtv-backend/contrib/*" > \
    /etc/dpkg/dpkg.cfg.d/mythtv-backend && \
   apt-get -yq --no-install-recommends install \
-    apache2 curl iputils-ping less lsb-release mariadb-client net-tools \
-    openssh-client openssh-server mythtv-backend=$MYTHTV_VERSION \
+    curl iputils-ping less lsb-release mariadb-client net-tools \
+    mythtv-backend=$MYTHTV_VERSION \
     mythtv-common=$MYTHTV_VERSION mythtv-transcode-utils=$MYTHTV_VERSION \
-    mythweb=$MYTHTV_VERSION libmyth-python libmythtv-perl php-mythtv psmisc \
-    sudo tzdata v4l-utils vim w3m x11-utils xauth xmltv xterm && \
-  rm /etc/ssh/ssh_host_*
+    libmyth-python libmythtv-perl php-mythtv php8.3 psmisc \
+    sudo tzdata v4l-utils vim w3m x11-utils xauth xmltv xterm
 
 COPY src/ /root/
 
 RUN \
-  sed -i -e "s/Listen 80/Listen $MYTHWEB_PORT/" /etc/apache2/ports.conf && \
-  sed -i -e "s/#Port 22/Port $SSH_PORT/" /etc/ssh/sshd_config && \
-  mv /root/mythweb.conf /root/mythweb-settings.conf \
-    /etc/apache2/sites-available/ && \
   usermod -u $MYTHTV_UID -s /bin/bash mythtv && \
   mkdir -p /var/lib/mythtv $APACHE_LOG_DIR && \
   echo "mythtv:mythtv" | chpasswd && \
   chown $MYTHTV_UID:$MYTHTV_GID /var/lib/mythtv && \
   ln -s /usr/share/doc/mythtv-backend/contrib/user_jobs/mythlink.pl /usr/bin
 
-EXPOSE $MYTHWEB_PORT $SSH_PORT 5000/udp 5002/udp 5004/udp 6543 6544 6549 \
-  65001 65001/udp 
-VOLUME $APACHE_LOG_DIR /etc/ssh
+EXPOSE 5000/udp 5002/udp 5004/udp 6543 6544 6549 65001 65001/udp 
+VOLUME $APACHE_LOG_DIR
 ENTRYPOINT ["/root/entrypoint.sh"]

--- a/images/mythtv-backend/README.md
+++ b/images/mythtv-backend/README.md
@@ -34,21 +34,11 @@ docker run -d --name mythtv \
   instantlinux/mythtv-backend:latest
 ~~~
 
-Reach mythtv-setup in the usual way after starting sshd on port 2022; default password is mythtv:
-~~~
-docker exec mythtvbackend_app_1 /usr/sbin/sshd
-ssh -p 2022 -X mythtv@<host-ip>
-mythtv-setup
-~~~
-
-If you're performing setup from a multi monitor system, the fullscreen mythtv-setup might not be entirely visible. In this case, use the following to limit the resolution
-~~~
-mythtv-setup -w -geometry 1280x720
-~~~
-
 Change the password by generating a new hashed password and setting mythtv-user-password secret.
 
-Look for MythTV status pages on port 6544, and MythWeb is serviced on 6760.
+Look for MythTV status pages and configuration UI on port 6544.
+
+Starting with v34, mythtv-setup is accessed via <pod-ip>:6544/setupwizard. Use that to define video sources, storage groups, and set up channels.
 
 ### Variables
 Variable | Default | Description
@@ -102,7 +92,7 @@ mythweb-auth | htpasswd for mythweb user(s) under k8s
 
 You probably need to configure XMLTV in place of the old mythfilldatabase method used to fetch listings from [Schedules Direct](https://www.schedulesdirect.org/). See the documentation [Setup Video Sources](https://www.mythtv.org/wiki/Setup_Video_Sources). This image includes the required packages but does not automate setup. It's beyond scope of this document to describe the process fully but here are some of the required steps:
 
-* Go into mythtv-setup, find your video source(s) and change the listings grabber to the new Schedules Direct xmltv setting for your location; make note of the video source name you're using and set a variable FILENAME to match 
+* Go into setupwizard, find your video source(s) and change the listings grabber to the new Schedules Direct xmltv setting for your location; make note of the video source name you're using and set a variable FILENAME to match 
 * Invoke a channel-scan
 * Have your Schedules Direct username and password ready and invoke from a command shell inside the container:
 ```

--- a/images/mythtv-backend/helm/Chart.yaml
+++ b/images/mythtv-backend/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/mythtv/mythtv
 type: application
-version: 0.1.12
-appVersion: "34.0-fixes.202502222320.d4f309f965"
+version: 0.1.13
+appVersion: "35.0-fixes.202504212209.eaa307f0b6"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/mythtv-backend/helm/values.yaml
+++ b/images/mythtv-backend/helm/values.yaml
@@ -10,7 +10,6 @@ deployment:
   - containerPort: 6543
   - containerPort: 6544
   - containerPort: 6549
-  - containerPort: 6760
   hostAliases:
   - ip: 127.0.1.1
     hostnames: [ pvr01 ]
@@ -24,10 +23,6 @@ deployment:
       cpu: 500m
       memory: 512Mi
 volumeMounts:
-- name: apache-log
-  mountPath: /var/log/apache2
-- name: ssh-config
-  mountPath: /etc/ssh
 - name: data
   mountPath: /var/mythdata
 - name: share
@@ -50,10 +45,6 @@ volumeMounts:
   readOnly: true
   subPath: mythtv-user-password
 volumes:
-- name: apache-log
-  emptyDir: {}
-- name: ssh-config
-  emptyDir: {}
 - name: data
   hostPath: { path: /var/mythtv }
 - name: videos
@@ -88,8 +79,7 @@ serviceAccount:
 service:
   clusterIP: None
   ports:
-  - { port: 6760, targetPort: 6760, name: mythweb }
-  - { port: 6544, targetPort: 6544, name: status }
+  - { port: 6544, targetPort: 6544, name: ui }
   type: ClusterIP
 autoscaling:
   enabled: false

--- a/images/rsyslogd/helm/values.yaml
+++ b/images/rsyslogd/helm/values.yaml
@@ -11,6 +11,12 @@ deployment:
     tz: UTC
   containerPorts:
   - containerPort: 514
+  resources:
+    limits:
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
   
 volumeMounts:
 - name: config

--- a/k8s/scripts/k8sudo
+++ b/k8s/scripts/k8sudo
@@ -2,20 +2,21 @@
 # This script encrypts the admin key used for kubectl --context=sudo
 
 CMD=$1
+[ -z "$STATUS_FILE" ] && STATUS_FILE=/var/adm/admin/secrets/.k8sadm.txt
 [ -z "$ADMIN_KEY" ] && ADMIN_KEY=~/.kube/admin-user.key
 umask 077
 if [ $CMD = sudo ]; then
  openssl enc -d -pbkdf2 -md md5 -aes-256-cbc \
    -out $ADMIN_KEY -in ${ADMIN_KEY}.enc
- date > /tmp/.k8sadm.txt
+ date > $STATUS_FILE
 elif [ $CMD = lock ]; then
  if [ ! -f ${ADMIN_KEY}.enc ]; then
    openssl enc -e -pbkdf2 -md md5 -aes-256-cbc -salt \
      -in $ADMIN_KEY -out ${ADMIN_KEY}.enc
    fi
-   if [ -s /tmp/.k8sadm.txt ]; then
+   if [ -s $STATUS_FILE ]; then
      rm $ADMIN_KEY
-     rm /tmp/.k8sadm.txt
+     rm $STATUS_FILE
      echo "** Privileges dropped **"
    else
      echo "** Nothing to do **"
@@ -60,7 +61,7 @@ A check-file-exists Nagios NRPE script (credit: github.com/dnmvisser)
    k8sudo:
      local: True
      plugin: check-file-exists
-     options: --absent -w -f /tmp/.k8sadm.txt
+     options: --absent -w -f /var/adm/admin/secrets/.k8sadm.txt
 
 EOF
 else


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Upgrade mythtv-backend image: `35.0-fixes.202504212209.eaa307f0b6`
* Remove sshd, apache2 and mythtv-setup packages from mythtv-backend (deprecated since 34.0)
* Fix `k8sudo` monitoring (PR #196)
* Increase memory limit of rsyslogd to keep oom killer at bay

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

Routine security updates.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
