### PR TITLE
SYS-651 kubernetes v1.32.4 and minor housekeeping

### DIFF
--- a/ansible/roles/docker_node/defaults/main.yml
+++ b/ansible/roles/docker_node/defaults/main.yml
@@ -5,7 +5,7 @@ docker_defaults:
   apt_repo:
     key: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
     package_name: docker-ce
-    package_ver: 5:27.5.1-1~ubuntu.24.04~noble
+    package_ver: 5:28.1.1-1~ubuntu.24.04~noble
     repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
     url: https://download.docker.com/linux/ubuntu/gpg
   certs:

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -13,9 +13,9 @@ k8s_defaults:
   admin_config: /etc/kubernetes/admin.conf
   config_fetch_always: false
   apt_repo:
-    # TODO parameterize hardcoded 1.31 value
-    repo: deb [signed-by=/etc/apt/keyrings/kubernetes.asc] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /
-    url: https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key
+    # TODO parameterize hardcoded 1.32 value
+    repo: deb [signed-by=/etc/apt/keyrings/kubernetes.asc] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /
+    url: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
   cplane_hostip: "{{ hostvars[groups['k8s_cplane'][0]]['ansible_default_ipv4']['address'] | default(groups['k8s_cplane'][0]) }}"
   cplane_vip: "{{ hostvars[groups['k8s_cplane'][0]]['ansible_default_ipv4']['address'] | default(groups['k8s_cplane'][0]) }}"
   # TODO: might be able to retire cri-dockerd
@@ -32,9 +32,9 @@ k8s_defaults:
     name: kubelet
     state: restarted
   service_network: 10.96.0.0/12
-  version: 1.31.7
+  version: 1.32.4
   coredns_version: v1.11.3
-  cni_version: 1.5.1
+  cni_version: 1.6.0
 k8s_override: {}
 k8s: "{{ k8s_defaults | combine(k8s_override) }}"
 

--- a/k8s/helm/gitea/values.yaml
+++ b/k8s/helm/gitea/values.yaml
@@ -91,7 +91,6 @@ fullnameOverride: ""
 
 serviceAccount: {}
 service:
-service:
   clusterIP: None
   ports:
   - { port: 80, targetPort: 3000, name: gitea }

--- a/k8s/helm/restic/values.yaml
+++ b/k8s/helm/restic/values.yaml
@@ -25,9 +25,11 @@ deployment:
   resources:
     limits:
       memory: 2048Mi
+      ephemeral-storage: 50Mi
     requests:
       cpu: 200m
       memory: 512Mi
+      ephemeral-storage: 10Mi
 volumeMounts:
 - mountPath: /var/spool/cron/crontabs/root
   name: config

--- a/k8s/install/monitor.yaml
+++ b/k8s/install/monitor.yaml
@@ -70,5 +70,5 @@ spec:
           service:
             name: $SERVICE_NAME
             port:
-              number: $PORT_NAGIOSQL
+              number: 80
         pathType: Prefix


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Updates:
* k8s now `1.32.4`
* docker-ce now `28.1.1`
* cni now `1.6.0`
* gitea: helm chart had spurious `service` value
* restic: helm chart now restricted to smaller ephemeral limit
* monitor: yaml had incorrect port number

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Routine patching and cleanup

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
