### PR TITLE
SYS-653 update ansible bind9 role's root.hints

### DIFF
--- a/ansible/roles/bind9/defaults/main.yml
+++ b/ansible/roles/bind9/defaults/main.yml
@@ -8,6 +8,23 @@ bind9_defaults:
   - 127.0.0.1
   dump_file: /var/cache/bind/named_dump.db
   managed_keys_directory: /var/cache/bind
+  root_params:
+    ttl: 3600000
+    updated: May 22, 2025
+  root_servers:
+    A: { A: 198.41.0.4, AAAA: '2001:503:ba3e::2:30', org: NS.INTERNIC.NET }
+    B: { A: 170.247.170.2, AAAA: '2801:1b8:10::b', org: NS1.ISI.EDU }
+    C: { A: 192.33.4.12, AAAA: '2001:500:2::c', org: C.PSI.NET }
+    D: { A: 199.7.91.13, AAAA: '2001:500:2d::d', org: TERP.UMD.EDU }
+    E: { A: 192.203.230.10, AAAA: '2001:500:a8::e', org: NS.NASA.GOV }
+    F: { A: 192.5.5.241, AAAA: '2001:500:2f::f', org: NS.ISC.ORG }
+    G: { A: 192.112.36.4, AAAA: '2001:500:12::d0d', org: NS.NIC.DDN.MIL }
+    H: { A: 198.97.190.53, AAAA: '2001:500:1::53', org: AOS.ARL.ARMY.MIL }
+    I: { A: 192.36.148.17, AAAA: '2001:7fe::53', org: NIC.NORDU.NET }
+    J: { A: 192.58.128.30, AAAA: '2001:503:c27::2:30', org: VERISIGN }
+    K: { A: 193.0.14.129, AAAA: '2001:7fd::1', org: RIPE }
+    L: { A: 199.7.83.42, AAAA: '2001:500:9f::42', org: ICANN }
+    M: { A: 202.12.27.33, AAAA: '2001:dc3::35', org: WIDE }
   server_ips: []
   statistics_file: /var/cache/bind/named.stats
   transfer_secret: "{{ vault_bind9_secret }}"

--- a/ansible/roles/bind9/tasks/main.yml
+++ b/ansible/roles/bind9/tasks/main.yml
@@ -21,6 +21,7 @@
   template:
     dest: /etc/bind/root.hint
     src: root.hint.j2
+  notify: Restart bind9
 
 - name: bind9 service
   service:

--- a/ansible/roles/bind9/templates/root.hint.j2
+++ b/ansible/roles/bind9/templates/root.hint.j2
@@ -1,4 +1,4 @@
-; placed by ansible
+{{ ansible_managed | comment(decoration="; ") }}
 
 ;       This file holds the information on root name servers needed to 
 ;       initialize cache of Internet domain name servers
@@ -11,84 +11,14 @@
 ;           on server           FTP.INTERNIC.NET
 ;       -OR-                    RS.INTERNIC.NET
 ; 
-;       last update:     September 11, 2018 
-;       related version of root zone:     2018091102
+;       last update:     {{ bind9.root_params.updated }}
+;       related version of root zone:     xxxx
+{% for key, server in bind9.root_servers.items() %}
 ; 
-; FORMERLY NS.INTERNIC.NET 
+; OPERATED BY {{ server.org }}
 ;
-.                        3600000      NS    A.ROOT-SERVERS.NET.
-A.ROOT-SERVERS.NET.      3600000      A     198.41.0.4
-A.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:ba3e::2:30
-; 
-; FORMERLY NS1.ISI.EDU 
-;
-.                        3600000      NS    B.ROOT-SERVERS.NET.
-B.ROOT-SERVERS.NET.      3600000      A     199.9.14.201
-B.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:200::b
-; 
-; FORMERLY C.PSI.NET 
-;
-.                        3600000      NS    C.ROOT-SERVERS.NET.
-C.ROOT-SERVERS.NET.      3600000      A     192.33.4.12
-C.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2::c
-; 
-; FORMERLY TERP.UMD.EDU 
-;
-.                        3600000      NS    D.ROOT-SERVERS.NET.
-D.ROOT-SERVERS.NET.      3600000      A     199.7.91.13
-D.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2d::d
-; 
-; FORMERLY NS.NASA.GOV
-;
-.                        3600000      NS    E.ROOT-SERVERS.NET.
-E.ROOT-SERVERS.NET.      3600000      A     192.203.230.10
-E.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:a8::e
-; 
-; FORMERLY NS.ISC.ORG
-;
-.                        3600000      NS    F.ROOT-SERVERS.NET.
-F.ROOT-SERVERS.NET.      3600000      A     192.5.5.241
-F.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:2f::f
-; 
-; FORMERLY NS.NIC.DDN.MIL
-;
-.                        3600000      NS    G.ROOT-SERVERS.NET.
-G.ROOT-SERVERS.NET.      3600000      A     192.112.36.4
-G.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:12::d0d
-; 
-; FORMERLY AOS.ARL.ARMY.MIL
-;
-.                        3600000      NS    H.ROOT-SERVERS.NET.
-H.ROOT-SERVERS.NET.      3600000      A     198.97.190.53
-H.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:1::53
-; 
-; FORMERLY NIC.NORDU.NET
-;
-.                        3600000      NS    I.ROOT-SERVERS.NET.
-I.ROOT-SERVERS.NET.      3600000      A     192.36.148.17
-I.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fe::53
-; 
-; OPERATED BY VERISIGN, INC.
-;
-.                        3600000      NS    J.ROOT-SERVERS.NET.
-J.ROOT-SERVERS.NET.      3600000      A     192.58.128.30
-J.ROOT-SERVERS.NET.      3600000      AAAA  2001:503:c27::2:30
-; 
-; OPERATED BY RIPE NCC
-;
-.                        3600000      NS    K.ROOT-SERVERS.NET.
-K.ROOT-SERVERS.NET.      3600000      A     193.0.14.129
-K.ROOT-SERVERS.NET.      3600000      AAAA  2001:7fd::1
-; 
-; OPERATED BY ICANN
-;
-.                        3600000      NS    L.ROOT-SERVERS.NET.
-L.ROOT-SERVERS.NET.      3600000      A     199.7.83.42
-L.ROOT-SERVERS.NET.      3600000      AAAA  2001:500:9f::42
-; 
-; OPERATED BY WIDE
-;
-.                        3600000      NS    M.ROOT-SERVERS.NET.
-M.ROOT-SERVERS.NET.      3600000      A     202.12.27.33
-M.ROOT-SERVERS.NET.      3600000      AAAA  2001:dc3::35
+.                        {{ bind9.root_params.ttl }}      NS    {{ key }}.ROOT-SERVERS.NET.
+{{ key }}.ROOT-SERVERS.NET.      {{ bind9.root_params.ttl }}      A     {{ server.A }}
+{{ key }}.ROOT-SERVERS.NET.      {{ bind9.root_params.ttl }}      AAAA  {{ server.AAAA }}
+{% endfor -%}
 ; End of file


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Ansible role `bind9` is hereby updated with the 22-May-2025 version of root.hints from ftp.internic.net. Moved most of the values from the raw template into defaults.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
The 2018-vintage  file had at least one stale value.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] Documentation has been updated
- [x ] Dependencies have been updated and verified
