### PR TITLE
SYS-654 fix updated dovecot build

### DIFF
--- a/images/dovecot/Dockerfile
+++ b/images/dovecot/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
 ARG DOVECOT_VERSION=2.4.1-r2
-ARG MKCERT_SHA=24b6988d1709e71c24dcf94ffce5db93bd2e89dc5cbec1ac3c173de5274b68dd
+ARG MKCERT_SHA=d1efad065f9ef34da372847ff4a4d5ffd86b97410b303d8a43ea25aa2119c86d
 
 ENV LDAP_SECRETNAME=ldap-ro-password \
     SSL_DH=
@@ -19,7 +19,7 @@ RUN echo '@old http://dl-cdn.alpinelinux.org/alpine/v3.11/main' \
       >>/etc/apk/repositories && \
     apk add --no-cache dovecot=$DOVECOT_VERSION dovecot-ldap=$DOVECOT_VERSION \
       procmail@old && \
-    rm /etc/ssl/dovecot/server.* && cd /usr/local/bin && \
+    cd /usr/local/bin && \
     wget -q https://raw.githubusercontent.com/dovecot/core/release-2.4.1/doc/mkcert.sh && \
     echo "$MKCERT_SHA  mkcert.sh" | sha256sum -c && \
     chmod 755 /usr/local/bin/mkcert.sh


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
When installing new version of dovecot, Dockerfile no longer needs to purge a directory under `/etc/ssl`.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Last update broke the build.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing and CI.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
