### PR TITLE
Start container with tini

### DIFF
--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -28,10 +28,10 @@ HEALTHCHECK CMD upsc $NAME@localhost:3493 2>&1|grep -q stale && \
 
 RUN apk add --no-cache dash && \
     apk add --update --no-cache nut=$NUT_VERSION \
-      busybox linux-pam \
+      busybox tini linux-pam \
       libcrypto3 libssl3 \
       libusb musl net-snmp-libs util-linux
 
 EXPOSE 3493
 COPY entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/images/nut-upsd/Dockerfile.arm32
+++ b/images/nut-upsd/Dockerfile.arm32
@@ -28,7 +28,7 @@ RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' \
     echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' \
       >>/etc/apk/repositories && \
     apk add --update nut@testing=$NUT_VERSION \
-      libcrypto1.1@edge libssl1.1@edge net-snmp-libs@edge
+      libcrypto1.1@edge libssl1.1@edge net-snmp-libs@edge tini
 
 EXPOSE 3493
 COPY entrypoint.sh /usr/local/bin/

--- a/images/nut-upsd/Dockerfile.arm64
+++ b/images/nut-upsd/Dockerfile.arm64
@@ -28,7 +28,7 @@ RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' \
     echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' \
       >>/etc/apk/repositories && \
     apk add --update nut@testing=$NUT_VERSION \
-      libcrypto1.1@edge libssl1.1@edge net-snmp-libs@edge
+      libcrypto1.1@edge libssl1.1@edge net-snmp-libs@edge tini
 
 EXPOSE 3493
 COPY entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
## Summary of Changes

This PR changes the entry point to use [tini](https://github.com/krallin/tini) to start the container.

## Why is this change being made?

This allows signals to be properly sent to the container. E.g. it no longer takes 10 seconds to kill the container since the kill command is successfully reaching upsmon.

## How was this tested? How can the reviewer verify your testing?

I tested this using a [PR](https://github.com/Brandawg93/PeaNUT/pull/282) I'm working on for PeaNUT.

## Completion checklist

- [ ] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [ ] Documentation has been updated
- [ ] Dependencies have been updated and verified
