### PR TITLE
SYS-658 remove faulty intel GPU driver for mythtv frontend

### DIFF
--- a/ansible/roles/mythfrontend/defaults/main.yml
+++ b/ansible/roles/mythfrontend/defaults/main.yml
@@ -21,6 +21,9 @@ display_driver_defaults:
     - 1280x720
     - 1920x1080
     - 1980x1080i
+  xorg:
+    video_intel: false
+
 display_driver: "{{ display_driver_defaults | combine(display_driver_overrides) }}"
 
 ir_device:

--- a/ansible/roles/mythfrontend/tasks/drivers/intel.yml
+++ b/ansible/roles/mythfrontend/tasks/drivers/intel.yml
@@ -2,11 +2,17 @@
 # intel.yml
 
 - name: Load intel driver at startup
-  template:
+  ansible.builtin.template:
     dest: "{{ x11_config_path }}/20-{{ display_driver.type }}.conf"
     src: 20-{{ display_driver.type }}.conf.j2
 
 - name: Limit screen resolution to specified list
-  template:
+  ansible.builtin.template:
     dest: "{{ x11_config_path }}/20-screen.conf"
     src: 20-screen.conf.j2
+
+- name: Disable obsolete xorg driver for Intel GPU
+  ansible.builtin.package:
+    name: xserver-xorg-video-intel
+    state: absent
+  when: not display_driver.xorg.video_intel


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
When building a MythTV frontend with ansible, this removes the faulty Intel GPU driver for X11 (package name `xserver-xorg-video-intel`).

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Support for those packages under Xorg has apparently been dropped, to the point that hardware acceleration no longer works if that package is present. This forces X11 initialization to properly recognize the `modesetting` driver which remains supported.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
