### PR TITLE
SYS-657 use built-in TOTP for guacamole, instead of Authelia

### DIFF
--- a/k8s/helm/guacamole/subcharts/guacamole-server/values.yaml
+++ b/k8s/helm/guacamole/subcharts/guacamole-server/values.yaml
@@ -23,11 +23,6 @@ service:
   type: ClusterIP
 autoscaling:
   enabled: false
-
-authelia:
-  fqdn: authtotp.example.com
-  ip: 10.101.1.5
-  path: /guacamole/\#/login
 ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
@@ -38,5 +33,3 @@ ingress:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header Connection $http_connection;
       proxy_set_header Upgrade $http_upgrade;
-ingressTOTP:
-  enabled: true

--- a/k8s/helm/guacamole/values.yaml
+++ b/k8s/helm/guacamole/values.yaml
@@ -11,11 +11,18 @@ guacamole-server:
   tlsHostname: guacamole.example.com
   deployment:
     env:
+      # TODO: enable the BAN extension introduced in 1.6.0; for now
+      #   the ingress-nginx proxy is continuously blocked by spurious
+      #   auth failures, and break-in attempts are blocked by TOTP
+      ban_enabled: "false"
       guacd_hostname: guacamole-guacd
       guacd_port: 4822
+      ldap_enabled: "false"
       mysql_database: guacamole
       mysql_hostname: db00
-      mysql_user: guacamole_user
+      mysql_username: guacamole_user
+      skip_if_unavailable: ldap
+      totp_enabled: "true"
     xenv:
     - name: MYSQL_PASSWORD
       valueFrom:

--- a/k8s/helm/guacamole/values.yaml
+++ b/k8s/helm/guacamole/values.yaml
@@ -12,8 +12,8 @@ guacamole-server:
   deployment:
     env:
       # TODO: enable the BAN extension introduced in 1.6.0; for now
-      #   the ingress-nginx proxy is continuously blocked by spurious
-      #   auth failures, and break-in attempts are blocked by TOTP
+      #   break-in attempts are blocked by TOTP because BAN requires
+      #   more ingress-nginx directives to provide proxy IP address
       ban_enabled: "false"
       guacd_hostname: guacamole-guacd
       guacd_port: 4822


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Fixes for the Apache guacamole helm chart:

* Explicitly disable extensions `ban` and `ldap` by default
* Eliminate references to Authelia TOTP
* Enable the built-in TOTP

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Version 1.6.0 added new defaults that break logins without additional configuration. LDAP needs additional configuration, so there's no point loading it without that configuration. The BAN extension also requires additional configuration when run behind a proxy, so it blocks all access whenever a brute-force attack happens (and such attacks continuously happen once the login URL becomes known to the hacker community). Authelia's TOTP is incompatible with login URLs that contain a `#` character, so to protect the system this PR adds TOTP by default. TOTP does not need additional configuration: if a user hasn't yet registered, by default the next login attempt will request registration.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
