### PR TITLE
SYS-661 bump ingress-nginx from 1.11.2 to 1.13.1; cert-manager to 1.16.1

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -196,22 +196,14 @@ include Makefile.sops
 # cert-manager
 ##########
 
+# Note - need both, to define the CRD and the ClusterIssuer resources
+#   make imports/cert-manager
+#   make install/cert-manager
+
 imports/cert-manager.yaml: imports/cert-manager-$(VERSION_CERT_MANAGER).yaml
 	ln -s $(notdir $<) $@
 imports/cert-manager-$(VERSION_CERT_MANAGER).yaml:
 	curl -sLo $@ https://github.com/jetstack/cert-manager/releases/download/v$(VERSION_CERT_MANAGER)/cert-manager.yaml
-
-# TODO: remove this once it's clear the above works without helm
-# When updating, do "helm delete --purge cert-manager" first
-cert-manager-helm: helm_install
-	helm install stable/cert-manager \
-	 --name cert-manager --namespace cert-manager \
-	 --set ingressShim.defaultIssuerName=letsencrypt-prod \
-	 --set ingressShim.defaultIssuerKind=ClusterIssuer \
-	 --set webhook.enabled=false \
-	 --kube-context=sudo
-	kubectl label namespace cert-manager --context=sudo \
-	 certmanager.k8s.io/disable-validation=true
 
 ##########
 # Add-ons

--- a/k8s/Makefile.versions
+++ b/k8s/Makefile.versions
@@ -4,11 +4,11 @@ export VERSION_LOGSPOUT      ?= v3.2.14
 export VERSION_NGINX         ?= 1.27.2-alpine
 
 # Third-party versions - other (quay.io, k8s.gcr.io, crunchydata.com)
-export VERSION_CERT_MANAGER   ?= 1.16.1
+export VERSION_CERT_MANAGER   ?= 1.16.5
 export VERSION_DEFAULTBACKEND ?= 1.5
 export VERSION_FLANNEL        ?= 0.26.1
 export VERSION_HELM           ?= 3.16.2
-export VERSION_INGRESS_NGINX  ?= 1.11.2
+export VERSION_INGRESS_NGINX  ?= 1.13.1
 export VERSION_METRICS        ?= 2.15.0
 
 # Held back versions - more effort to upgrade

--- a/k8s/install/ingress-nginx.yaml
+++ b/k8s/install/ingress-nginx.yaml
@@ -71,6 +71,7 @@ spec:
               fieldPath: metadata.namespace
         args:
         - /nginx-ingress-controller
+        - --configmap=$K8S_NAMESPACE/nginx-ingress-controller
         - --ingress-class=nginx
         - --election-id=ingress-controller-leader-external
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
@@ -241,7 +242,7 @@ rules:
       - "discovery.k8s.io"
     resources:
       - endpointslices
-    verbs: [get, list]
+    verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -277,3 +278,14 @@ data:
   $PORT_DOVECOT_IMAPD: $K8S_NAMESPACE/dovecot:$PORT_DOVECOT_IMAPD
   $PORT_DOVECOT_IMAPS: $K8S_NAMESPACE/dovecot:$PORT_DOVECOT_IMAPS
   $PORT_DOVECOT_SMTP: $K8S_NAMESPACE/dovecot:$PORT_DOVECOT_SMTP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-ingress-controller
+  namespace: $K8S_NAMESPACE
+data:
+  # needed for some services that use config snippets, e.g. for
+  #  adjusting fastcgi_buffers
+  annotations-risk-level: Critical
+  allowSnippetAnnotations: "true"


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Upgrades ingress-nginx to 1.13.1 and cert-manager to 1.16.1.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Routine security patching. See the [IngressNightmare](https://securitylabs.datadoghq.com/articles/ingress-nightmare-vulnerabilities-overview-and-remediation/) vulnerability report.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
