### PR TITLE
Issue 213 nut trixie

### DIFF
--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.name=nut-upsd \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
-ARG NUT_VERSION=2.8.2-r2
+ARG NUT_VERSION=2.8.3-r2
 ENV API_USER=upsmon \
     API_PASSWORD= \
     DESCRIPTION=UPS \
@@ -21,13 +21,16 @@ ENV API_USER=upsmon \
     SECRETNAME=nut-upsd-password \
     SERIAL= \
     SERVER=master \
+    ULIMIT=2048 \
     USER=nut \
     VENDORID=
 HEALTHCHECK CMD upsc $NAME@localhost:3493 2>&1|grep -q stale && \
     killall -TERM upsmon || true
 
-RUN apk add --no-cache dash && \
-    apk add --update --no-cache nut=$NUT_VERSION \
+RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/community' \
+      >>/etc/apk/repositories && \
+    apk add --no-cache dash && \
+    apk add --update --no-cache nut@edge=$NUT_VERSION \
       busybox linux-pam \
       libcrypto3 libssl3 \
       libusb musl net-snmp-libs util-linux

--- a/images/nut-upsd/README.md
+++ b/images/nut-upsd/README.md
@@ -51,6 +51,7 @@ SDORDER | | UPS shutdown sequence, set to -1 to disable shutdown
 SECRETNAME | nut-upsd-password | name of secret to use for API user
 SERIAL | | hardware serial number of UPS
 SERVER | master | master or slave priority for scripts
+ULIMIT | 2048 | open-files ulimit
 USER | nut | local user
 VENDORID | | vendor ID for ups.conf
 ### Notes
@@ -114,6 +115,8 @@ ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}==“09ae”, ATTRS{idProduct}==
 EOF
 udevadm control --reload-rules && udevadm trigger
 ```
+
+When starting up under Debian trixie, an out-of-memory error can be prevented by setting the nofile ulimit to a smaller value than system default: see [issue #1672](https://github.com/networkupstools/nut/issues/1672). The default is set here to 2048.
 
 ### Secrets
 

--- a/images/nut-upsd/entrypoint.sh
+++ b/images/nut-upsd/entrypoint.sh
@@ -69,6 +69,7 @@ chown $USER:$GROUP /dev/shm/nut
 echo 0 > /var/run/nut/upsd.pid && chown $USER:$GROUP /var/run/nut/upsd.pid
 echo 0 > /var/run/upsmon.pid
 
+ulimit -n $ULIMIT
 /usr/sbin/upsdrvctl -u root start
 /usr/sbin/upsd -u $USER
 exec /usr/sbin/upsmon -D


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Updates nut-upsd to version `2.8.3-r2` and adds a ULIMIT parameter with to set maximum open files (default 2048).

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->

Under Debian trixie, an [issue #1672](https://github.com/networkupstools/nut/issues/1672) causes an out-of-memory error due to a high system default value for this parameter. Reported here as issue #213 by @Certain1989.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

Local testing. Started a container and viewed the limits applied to upsd:
```
/ # ulimit -n
1048576
/ # echo $ULIMIT
2048
/ # ps aux
PID   USER     TIME  COMMAND
    1 root      0:00 /usr/sbin/upsmon -D
   22 root      0:00 /usr/lib/nut/usbhid-ups -a ups -u root
   24 nut       0:00 /usr/sbin/upsd -u nut
   25 nut       0:00 /usr/sbin/upsmon -D
   46 root      0:00 sh
   71 root      0:00 ps aux
/ # cat /proc/24/limits
Limit                     Soft Limit           Hard Limit           Units     
Max cpu time              unlimited            unlimited            seconds   
Max file size             unlimited            unlimited            bytes     
Max data size             unlimited            unlimited            bytes     
Max stack size            8388608              unlimited            bytes     
Max core file size        unlimited            unlimited            bytes     
Max resident set          unlimited            unlimited            bytes     
Max processes             unlimited            unlimited            processes 
Max open files            2048                 2048                 files     <--- note new reduced value
Max locked memory         8388608              8388608              bytes     
Max address space         unlimited            unlimited            bytes     
Max file locks            unlimited            unlimited            locks     
Max pending signals       62785                62785                signals   
Max msgqueue size         819200               819200               bytes     
Max nice priority         0                    0                    
Max realtime priority     0                    0                    
Max realtime timeout      unlimited            unlimited            us        
```
## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
