### PR TITLE
SYS-662 add node-local-dns cache from kubernetes distro

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -95,7 +95,7 @@ $(STACKS)::
 .PHONY: envsubst imports install namespace_config node_labels \
 	persistent remote_volumes secrets sops untaint_master
 
-IMPORTS      = cert-manager flannel
+IMPORTS      = cert-manager flannel nodelocaldns
 INSTALL_YAML = $(basename $(wildcard install/*.yaml)) \
           $(addprefix imports/, $(IMPORTS))
 VOLUMES_YAML = $(basename $(wildcard volumes/*.yaml))
@@ -204,6 +204,15 @@ imports/cert-manager.yaml: imports/cert-manager-$(VERSION_CERT_MANAGER).yaml
 	ln -s $(notdir $<) $@
 imports/cert-manager-$(VERSION_CERT_MANAGER).yaml:
 	curl -sLo $@ https://github.com/jetstack/cert-manager/releases/download/v$(VERSION_CERT_MANAGER)/cert-manager.yaml
+
+##########
+# node-local-dns
+##########
+imports/nodelocaldns.yaml: imports/nodelocaldns-$(VERSION_NODE_LOCAL_DNS).yaml
+	ln -s $(notdir $<) $@
+imports/nodelocaldns-$(VERSION_NODE_LOCAL_DNS).yaml:
+	curl -sLo $@ https://raw.githubusercontent.com/kubernetes/kubernetes/refs/tags/v$(VERSION_NODE_LOCAL_DNS)/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+	sed -i -e "s/__PILLAR__LOCAL__DNS__/$(NODE_LOCAL_DNS_IP)/g; s/__PILLAR__DNS__DOMAIN__/cluster.local/g; s/__PILLAR__DNS__SERVER__/$(COREDNS_IP)/g" $@
 
 ##########
 # Add-ons

--- a/k8s/Makefile.vars
+++ b/k8s/Makefile.vars
@@ -32,10 +32,10 @@ export TZ                   ?= UTC
 export K8S_INGRESS_NGINX_IP ?= 10.101.1.2
 export AUTHELIA_IP          ?= 10.101.1.5
 export MONITOR_EXT_IP       ?= 192.168.1.20
-# export PROMETHEUS_IP	    ?= 10.101.1.21
-# export PROM_ALERT_IP	    ?= 10.101.1.22
+# export PROMETHEUS_IP      ?= 10.101.1.21
+# export PROM_ALERT_IP      ?= 10.101.1.22
 export RSYSLOGD_IP          ?= 10.101.1.40
-export COREDNS_IP	    ?= 10.96.0.10
+export COREDNS_IP           ?= 10.96.0.10
 export NODE_LOCAL_DNS_IP    ?= 169.254.0.10
 
 # Exposed nodePorts - install/ingress-nginx.yaml

--- a/k8s/Makefile.vars
+++ b/k8s/Makefile.vars
@@ -35,6 +35,8 @@ export MONITOR_EXT_IP       ?= 192.168.1.20
 # export PROMETHEUS_IP	    ?= 10.101.1.21
 # export PROM_ALERT_IP	    ?= 10.101.1.22
 export RSYSLOGD_IP          ?= 10.101.1.40
+export COREDNS_IP	    ?= 10.96.0.10
+export NODE_LOCAL_DNS_IP    ?= 169.254.0.10
 
 # Exposed nodePorts - install/ingress-nginx.yaml
 export NODEPORT_HTTP         ?= 30080

--- a/k8s/Makefile.versions
+++ b/k8s/Makefile.versions
@@ -10,6 +10,7 @@ export VERSION_FLANNEL        ?= 0.26.1
 export VERSION_HELM           ?= 3.16.2
 export VERSION_INGRESS_NGINX  ?= 1.13.1
 export VERSION_METRICS        ?= 2.15.0
+export VERSION_NODE_LOCAL_DNS ?= 1.32.6
 
 # Held back versions - more effort to upgrade
 export VERSION_CALICO        ?= 3.16.5

--- a/k8s/helm/grafana/Chart.yaml
+++ b/k8s/helm/grafana/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
   version: 0.1.8
   repository: https://instantlinux.github.io/docker-tools
 - name: prometheus
-  version: 0.1.0
+  version: 0.1.1
   repository: file://subcharts/prometheus
   condition: prometheus.enabled
 - name: alertmanager

--- a/k8s/helm/grafana/subcharts/prometheus/Chart.yaml
+++ b/k8s/helm/grafana/subcharts/prometheus/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://hub.docker.com/r/prom/prometheus
 type: application
-version: 0.1.0
-appVersion: "v3.3.1"
+version: 0.1.1
+appVersion: "v3.5.0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/grafana/subcharts/prometheus/values.yaml
+++ b/k8s/helm/grafana/subcharts/prometheus/values.yaml
@@ -10,18 +10,9 @@ deployment:
   nodeSelector:
     service.prometheus: allow
 volumeMounts:
-- mountPath: /etc/prometheus/prometheus.yml
+- mountPath: /etc/prometheus
   name: config
   readOnly: true
-  subPath: prometheus.yml
-- mountPath: /etc/prometheus/alert-rules.yml
-  name: config
-  readOnly: true
-  subPath: alert-rules.yml
-- mountPath: /etc/prometheus/targets.json
-  name: config
-  readOnly: true
-  subPath: targets.json
 - mountPath: /prometheus
   name: data
 volumes:
@@ -96,12 +87,33 @@ configmap:
           regex: ^myth.*
           target_label: alertSuppress
           replacement: true
+      - job_name: dns-cache
+        file_sd_configs:
+        - files: [ k8s-workers.json ]
+        relabel_configs:
+        - source_labels: [__address__]
+          target_label: instance
+        - source_labels: [ __address__ ]
+          target_label: __address__
+          replacement: '${1}:9253'
     targets.json: |
       # Override the targets with your nodes list, comma-separated
       [
         {
           "labels": {
             "job": "hw-nodes"
+          },
+          "targets": [
+            "localhost"
+          ]
+        }
+      ]
+    k8s-workers.json: |
+      # Override the targets with your k8s worker list, comma-separated
+      [
+        {
+          "labels": {
+            "job": "dns-cache"
           },
           "targets": [
             "localhost"


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Defines in the k8s `Makefile` the `nodelocaldns` import from kubernetes/kubernetes distribution repo. The sequence:
```
make imports/nodelocaldns.yaml
make imports/nodelocaldns
```
will add a daemonset and related services to add a DNS resolver at 169.254.0.10, and reconfigure kube-proxy to automatically redirect traffic 10.96.0.10 from all pods on all workers to the new address. 

A prometheus scraper for grafana is added here as well, to support [dashboard 11759](https://grafana.com/grafana/dashboards/11759-coredns-with-nodelocaldns/). And: bumped Prometheus version from 3.3.1 to 3.5.0.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
UDP traffic between k8s nodes isn't reliable, especially under load. This is the widely-documented workaround to improve DNS reliability.

## How was this tested? How can the reviewer verify your testing?

Local testing.
<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
