### PR TITLE
SYS-663 kubernetes upgrade to 1.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The cluster-deployment tools here include helm charts and ansible playbooks to s
 | mysqldump | [![](https://img.shields.io/docker/v/instantlinux/mysqldump?sort=date)](https://hub.docker.com/r/instantlinux/mysqldump "Version badge") | per-database alternative to xtrabackup |
 | nagios | [![](https://img.shields.io/docker/v/instantlinux/nagios?sort=date)](https://hub.docker.com/r/instantlinux/nagios "Version badge") | Nagios Core v4 for monitoring |
 | nagiosql | [![](https://img.shields.io/docker/v/instantlinux/nagiosql?sort=date)](https://hub.docker.com/r/instantlinux/nagiosql "Version badge") | NagiosQL for configuring Nagios Core v4 |
+| node-local-dns | ** | caching resolver for reliable pod DNS |
 | nut-upsd | [![](https://img.shields.io/docker/v/instantlinux/nut-upsd?sort=date)](https://hub.docker.com/r/instantlinux/nut-upsd "Version badge") | Network UPS Tools |
 | openldap | [![](https://img.shields.io/docker/v/instantlinux/openldap?sort=date)](https://hub.docker.com/r/instantlinux/openldap "Version badge") | OpenLDAP authentication server |
 | restic | ** | backups |

--- a/ansible/roles/docker_node/defaults/main.yml
+++ b/ansible/roles/docker_node/defaults/main.yml
@@ -5,7 +5,7 @@ docker_defaults:
   apt_repo:
     key: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
     package_name: docker-ce
-    package_ver: 5:28.1.1-1~ubuntu.24.04~noble
+    package_ver: 5:28.4.0-1~ubuntu.24.04~noble
     repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
     url: https://download.docker.com/linux/ubuntu/gpg
   certs:

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -13,9 +13,9 @@ k8s_defaults:
   admin_config: /etc/kubernetes/admin.conf
   config_fetch_always: false
   apt_repo:
-    # TODO parameterize hardcoded 1.32 value
-    repo: deb [signed-by=/etc/apt/keyrings/kubernetes.asc] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /
-    url: https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key
+    # TODO parameterize hardcoded 1.34 value
+    repo: deb [signed-by=/etc/apt/keyrings/kubernetes.asc] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /
+    url: https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key
   cplane_hostip: "{{ hostvars[groups['k8s_cplane'][0]]['ansible_default_ipv4']['address'] | default(groups['k8s_cplane'][0]) }}"
   cplane_vip: "{{ hostvars[groups['k8s_cplane'][0]]['ansible_default_ipv4']['address'] | default(groups['k8s_cplane'][0]) }}"
   # TODO: might be able to retire cri-dockerd
@@ -26,20 +26,20 @@ k8s_defaults:
   local_vols: /var/lib/docker/k8s-volumes
   cplane: False
   pod_network: 10.244.0.0/16
-  pod_infra_container_image: registry.k8s.io/pause:3.10
+  pod_infra_container_image: registry.k8s.io/pause:3.10.1
   service:
     enabled: yes
     name: kubelet
     state: restarted
   service_network: 10.96.0.0/12
-  version: 1.32.4
+  version: 1.34.1
   coredns_version: v1.11.3
-  cni_version: 1.6.0
+  cni_version: 1.7.1
 k8s_override: {}
 k8s: "{{ k8s_defaults | combine(k8s_override) }}"
 
 cri_dockerd:
-  version: 0.3.15
+  version: 0.3.20
 
 oidc:
   client_id: client-not-yet-set

--- a/k8s/Makefile.versions
+++ b/k8s/Makefile.versions
@@ -9,8 +9,8 @@ export VERSION_DEFAULTBACKEND ?= 1.5
 export VERSION_FLANNEL        ?= 0.26.1
 export VERSION_HELM           ?= 3.16.2
 export VERSION_INGRESS_NGINX  ?= 1.13.1
-export VERSION_METRICS        ?= 2.15.0
-export VERSION_NODE_LOCAL_DNS ?= 1.32.6
+export VERSION_METRICS        ?= 2.17.0
+export VERSION_NODE_LOCAL_DNS ?= 1.34.1
 
 # Held back versions - more effort to upgrade
 export VERSION_CALICO        ?= 3.16.5

--- a/k8s/helm/restic/Chart.yaml
+++ b/k8s/helm/restic/Chart.yaml
@@ -6,10 +6,10 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/restic/restic
 type: application
-version: 0.1.18
+version: 0.1.19
 # Remember to update restic==<ver> in values.yaml as releases are published;
 #  the values.yaml file is not able to reference .Chart.appVersion
-appVersion: "0.18.0-r2"
+appVersion: "0.18.0-r4"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/restic/values.yaml
+++ b/k8s/helm/restic/values.yaml
@@ -17,7 +17,7 @@ deployment:
     mkdir -p /var/log/week && tail -f -n 0 /var/log/restic.log
   env:
     # Edit the version in Chart.yaml to keep consistent
-    app_version: 0.18.0-r2
+    app_version: 0.18.0-r4
     env: /etc/profile
     tz: UTC
   nodeSelector:


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Ansible updates for kubeadm, kubernetes-cni, cri-dockerd, and kube-state-metrics to support 1.34.x.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Routine security updates.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
