### PR TITLE
Issue #108 and issue #206 - nut-upsd enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,5 +121,6 @@ Thank you to the following contributors!
 * [Devin Bayer](https://github.com/akvadrako)
 * [Daniel Muller](https://github.com/DanielMuller)
 * [Brian Hechinger](https://github.com/bhechinger)
+* [David Powers](https://github.com/dapowers87)
 
 Contents created 2017-25 under [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0) by Rich Braun.

--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -8,13 +8,16 @@ LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 ARG NUT_VERSION=2.8.3-r2
-ENV API_USER=upsmon \
+ENV ACTIONS= \
+    API_USER=upsmon \
     API_PASSWORD= \
     DESCRIPTION=UPS \
     DRIVER=usbhid-ups \
     GROUP=nut \
+    INSTCMDS= \
     MAXAGE=15 \
     NAME=ups \
+    NOTIFYCMD= \
     NUT_DEBUG_LEVEL=0 \
     NUT_QUIET_INIT_SSL=true \
     NUT_QUIET_INIT_UPSNOTIFY=true \
@@ -34,7 +37,7 @@ RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/community' \
       >>/etc/apk/repositories && \
     apk add --no-cache dash && \
     apk add --update --no-cache nut@edge=$NUT_VERSION \
-      busybox linux-pam \
+      busybox curl linux-pam \
       libcrypto3 libssl3 \
       libusb musl net-snmp-libs util-linux
 

--- a/images/nut-upsd/README.md
+++ b/images/nut-upsd/README.md
@@ -38,13 +38,16 @@ These variables can be passed to the image from kubernetes.yaml or docker-compos
 
 Variable | Default | Description |
 -------- | ------- | ----------- |
+ACTIONS | | One or more user actions allowed (`set`, `fsd`)
 API_USER | upsmon| API user
 API_PASSWORD | | API password, if not using secret
 DESCRIPTION | UPS | user-assigned description
 DRIVER | usbhid-ups | driver (see [compatibility list](http://networkupstools.org/stable-hcl.html))
 GROUP | nut | local group
+INSTCMDS | | `all` or list of allowed commands, see [cmdvartab](https://github.com/networkupstools/nut/blob/master/data/cmdvartab) `CMDDESC` values
 MAXAGE | 15 | seconds before declaring driver non-responsive
 NAME | ups | user-assigned config name
+NOTIFYCMD | | full path of script to run upon notification
 NUT_DEBUG_LEVEL | 0 | verbosity of debug messages
 NUT_QUIET_INIT_SSL | true | inhibit superfluous startup warning
 NUT_QUIET_INIT_UPSNOTIFY | true | inhibit superfluous startup warning
@@ -58,6 +61,8 @@ ULIMIT | 2048 | open-files ulimit
 USER | nut | local user
 VENDORID | | vendor ID for ups.conf
 ### Notes
+
+To define a notify script, volume-mount it via your docker-compose file under /usr/local/bin and set the NOTIFYCMD environment variable. (*Don't* mount any executable scripts under /etc/nut, put them under /usr/local).
 
 If you need a driver other than `usbhid-ups`, the full list of supported drivers can be listed as follows:
 ```
@@ -121,9 +126,16 @@ udevadm control --reload-rules && udevadm trigger
 
 When starting up under Debian trixie, an out-of-memory error can be prevented by setting the nofile ulimit to a smaller value than system default: see [issue #1672](https://github.com/networkupstools/nut/issues/1672). The default is set here to 2048.
 
+If you see this error message on startup:
+```
+Unable to use old-style MONITOR line without a username
+Convert it and add a username to upsd.users - see the documentation
+```
+the most likely cause is a missing or empty secret (`nut-upsd-password`).
+
 ### Secrets
 
-If the API user needs a password, you have two ways to specify it: pass the value itself as environment variable API_PASSWORD, or define a Docker secret as follows:
+If the API user needs a password, you have two ways to specify it: pass the value itself as environment variable API_PASSWORD (which isn't secure), or define a Docker secret as follows:
 
 | Secret | Description |
 | ------ | ----------- |

--- a/images/nut-upsd/entrypoint.sh
+++ b/images/nut-upsd/entrypoint.sh
@@ -47,8 +47,13 @@ EOF
 [$API_USER]
         password = $API_PASSWORD
         upsmon $SERVER
-        instcmds = ALL
 EOF
+    for ACTION in ${ACTIONS//,/ }; do
+      echo "        actions = $ACTION" >> /etc/nut/upsd.users
+    done
+    for CMD in ${INSTCMDS//,/ }; do
+      echo "        instcmds = $CMD" >> /etc/nut/upsd.users
+    done
   fi
   if [ -e /etc/nut/local/upsmon.conf ]; then
     cp /etc/nut/local/upsmon.conf /etc/nut/upsmon.conf
@@ -57,6 +62,7 @@ EOF
 MONITOR $NAME@localhost 1 $API_USER $API_PASSWORD $SERVER
 RUN_AS_USER $USER
 EOF
+    [ -z "$NOTIFYCMD" ] || echo "NOTIFYCMD \"$NOTIFYCMD\"" >> /etc/nut/upsmon.conf
   fi
   touch /etc/nut/.setup
 fi

--- a/images/nut-upsd/helm/Chart.yaml
+++ b/images/nut-upsd/helm/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/networkupstools/nut
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "2.8.3-r2"
 dependencies:
 - name: chartlib

--- a/images/nut-upsd/helm/templates/app.yaml
+++ b/images/nut-upsd/helm/templates/app.yaml
@@ -1,3 +1,5 @@
+{{- include "chartlib.configmap" . }}
+---
 {{- include "chartlib.deployment" . }}
 ---
 {{- include "chartlib.hpa" . }}

--- a/images/nut-upsd/helm/values.yaml
+++ b/images/nut-upsd/helm/values.yaml
@@ -1,8 +1,11 @@
 # Default values for nut-upsd.
 deployment:
   env:
+    actions:
     driver: usbhid-ups
+    instcmds: 
     maxage: 15
+    notifycmd: 
     nut_debug_level: 0
     serial: mustbeset
   securityContext:
@@ -20,6 +23,13 @@ volumeMounts:
 # TODO make this work with pod security policies instead of securityContext
 # - name: usb
 #   mountpath: /dev/ttyUSB0
+
+# To define a notify script, add this in your value overrides, set
+#    configmap.enabled, and add script under configmap.data.notify
+# - name: notifycmd
+#   mountPath: /usr/local/bin/notify
+#   readOnly: true
+#   subPath: notify
 - name: secret
   mountPath: /run/secrets/nut-upsd-password
   readOnly: true
@@ -27,6 +37,11 @@ volumeMounts:
 volumes:
 # - name: usb
 #   hostPath: { path: /dev/ttyUSB0 }
+
+# - name: notifycmd
+#   configMap:
+#     name: nut-upsd
+#     defaultMode: 0555
 - name: secret
   secret:
     secretName: nut-upsd-password
@@ -50,3 +65,11 @@ service:
     targetPort: 3493
 autoscaling:
   enabled: false
+
+configmap:
+  enabled: false
+  name: nut-upsd
+  data: {}
+# data:
+#   notify: |
+#     your script here


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
This adds a bit of previously-unwanted complexity to the entrypoint startup script, risking bugginess down the road. But at request of multiple users, this PR defines these capabilities for the `nut-upsd` image and helm chart:

* Add support for ACTIONS, INSTCMDS and NOTIFYCMD variables
* Add support for a helm configmap to define a notify script under kubernetes
* Add `curl` package for use by scripts
* Clarify doc in the README to make troubleshooting easier / less necessary

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
As requested by @paolofaz, @474N, @dmcc, @markuswells in issues #108, #128, #206, #226.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Lots of local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
