### PR TITLE
Fix mythtv-backend config.xml template substitution

### DIFF
--- a/images/mythtv-backend/src/entrypoint.sh
+++ b/images/mythtv-backend/src/entrypoint.sh
@@ -34,6 +34,14 @@ if [ ! -f $MYTHHOME/.Xauthority ]; then
 fi
 
 cp /root/config.xml /etc/mythtv/
+
+# Substitute environment variables in config.xml
+sed -i -e "s/{{ DBNAME }}/$DBNAME/" \
+    -e "s/{{ DBPASSWORD }}/$DBPASSWORD/" \
+    -e "s/{{ DBSERVER }}/$DBSERVER/" \
+    -e "s/{{ LOCALHOSTNAME }}/$LOCALHOSTNAME/" \
+    /etc/mythtv/config.xml
+
 chmod 600 /etc/mythtv/config.xml && chown mythtv /etc/mythtv/config.xml
 
 for retry in $(seq 1 10); do


### PR DESCRIPTION
## Summary of Changes

Restore template variable substitution in the mythtv-backend entrypoint script. This substitution was accidentally removed in commit 451463f when upgrading to MythTV 35.0 and removing Apache/MythWeb support.

The config.xml file contains template placeholders (`{{ DBSERVER }}`, `{{ DBNAME }}`, `{{ DBPASSWORD }}`, `{{ LOCALHOSTNAME }}`) that must be replaced with actual environment variable values during container startup.

This PR addresses issue: https://github.com/instantlinux/docker-tools/issues/242

## Why is this change being made?

Without template substitution, the mythbackend application cannot connect to the database. The application reads the literal template strings from config.xml and attempts to connect to a database host named `{{ DBSERVER }}`, which fails with connection errors like:

```
I  Start up testing connections. DB {{ DBSERVER }}, BE , attempt 0, status dbAwake, Delay: 2000
E  Unable to connect to database!
```

This is a regression introduced in commit 451463f (April 24, 2025).

## How was this tested? How can the reviewer verify your testing?

The fix can be verified by:

1. Building the docker image with this change
2. Running it with environment variables: `DBSERVER=127.0.0.1 DBNAME=mythconverg`
3. Checking that the config.xml has the variables substituted: `docker exec <container> grep -A5 '<Database>' /etc/mythtv/config.xml`
4. Verifying that the application successfully connects to the database instead of failing with 'Cannot login to database' errors

The change is minimal and directly restores the template substitution logic that was present before commit 451463f.

## Completion checklist
- [x] The change has been tested with the mythtv-backend image
- [x] This is a targeted bugfix for a regression
- [x] The change restores previously working functionality