### PR TITLE
SYS-668 database reconnect config for kea; bump grafana helm version

### DIFF
--- a/images/dhcpd-dns-pxe/README.md
+++ b/images/dhcpd-dns-pxe/README.md
@@ -5,7 +5,7 @@ Serve DNS and DHCP from one or more small Alpine Linux container(s). This suppli
 
 ### Usage
 
-In kubernetes.yaml / docker-compose.yml, set the environment variables for your environment.
+In docker-compose.yml or helm, set the environment variables for your environment.
 
 Mount these under /etc:
 
@@ -19,7 +19,7 @@ GRANT USAGE ON *.* TO `kea`@`%` IDENTIFIED BY '<password>';
 GRANT ALL PRIVILEGES ON `kea`.* TO `kea`@`%`;
 ```
 
-See the kubernetes.yaml provided here. If you're using Swarm, see the docker-compose.yml file provided here in the source directory. This repo has complete instructions for
+If you're using Swarm, see the docker-compose.yml file provided here in the source directory. This repo has complete instructions for
 [building a kubernetes cluster](https://github.com/instantlinux/docker-tools/blob/main/k8s/README.md) where you can launch with [helm](https://github.com/instantlinux/docker-tools/tree/main/images/dhcpd-dns-pxe/helm), or [kubernetes.yaml](https://github.com/instantlinux/docker-tools/blob/main/images/dhcpd-dns-pxe/kubernetes.yaml) using _make_ and customizing [Makefile.vars](https://github.com/instantlinux/docker-tools/blob/main/k8s/Makefile.vars) after cloning this repo:
 ~~~
 git clone https://github.com/instantlinux/docker-tools.git
@@ -27,7 +27,7 @@ cd docker-tools/k8s
 make dhcpd-dns-pxe
 ~~~
 
-You can build a failsafe cluster of DHCP servers under kubernetes using the helm chart included here. Define a ConfigMap with your reservations defined as shown in kea documentation, and hosts defined as in the dnsmasq documentation. If a replica goes down, the others will continue to assign addresses. They won't conflict thanks to the way DHCP protocol works; a client will use the first address offered and ignore any additional offers from the server pool. Subsequent requests will be checked against the reservations database.
+This builds a failsafe cluster of DHCP servers under kubernetes using the helm chart. Define a ConfigMap with your reservations defined as shown in kea documentation, and hosts defined as in the dnsmasq documentation. If a replica goes down, the others will continue to assign addresses. They won't conflict thanks to the way DHCP protocol works; a client will use the first address offered and ignore any additional offers from the server pool. Subsequent requests will be checked against the reservations database.
 
 Verified to work with a single subnet and with the limited set of DHCP/DNS options supported in environment vars defined here. Additional options as defined in the [dnsmasq man page](https://linux.die.net/man/8/dnsmasq) can be specified as any .conf file under /etc/dnsmasq.d/local volume mount, and for dhcpd as any .conf file under /etc/dhcpd.d/local.
 

--- a/images/dhcpd-dns-pxe/src/kea.conf.j2
+++ b/images/dhcpd-dns-pxe/src/kea.conf.j2
@@ -12,11 +12,15 @@
     "allocator": "random",
     "host-reservation-identifiers": [ "hw-address" ],
     "lease-database": {
-	"type": "mysql",
-	"host": "{{ DB_HOST }}",
-	"name": "{{ DB_NAME }}",
-	"user": "{{ DB_USER }}",
-	"password": "{{ DB_PASS }}"
+      "type": "mysql",
+      "host": "{{ DB_HOST }}",
+      "name": "{{ DB_NAME }}",
+      "user": "{{ DB_USER }}",
+      "password": "{{ DB_PASS }}",
+      "max-reconnect-tries": 200,
+      "on-fail": "stop-retry-exit",
+      "reconnect-wait-time": 3000,
+      "retry-on-startup": true
     },
     "max-valid-lifetime": 14400,
     "valid-lifetime": 3600,

--- a/images/dovecot/helm/Chart.yaml
+++ b/images/dovecot/helm/Chart.yaml
@@ -7,11 +7,12 @@ sources:
 - https://github.com/vdukhovni/dovecot
 type: application
 version: 0.1.11
-appVersion: "2.4.1-r2"
+  # appVersion: "2.4.1-r2"
+appVersion: "2.3.21.1-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8
   repository: https://instantlinux.github.io/docker-tools
 - name: data-sync
-  version: 0.1.14
+  version: 0.1.3
   repository: https://instantlinux.github.io/docker-tools

--- a/images/dovecot/helm/templates/configmap.yaml
+++ b/images/dovecot/helm/templates/configmap.yaml
@@ -7,19 +7,23 @@ metadata:
     {{- include "local.labels" . | nindent 4 }}
 data:
   dovecot.conf: |
+    dovecot_config_version = 2.4
     auth_mechanisms = plain login
-    disable_plaintext_auth = yes
+    auth_allow_cleartext = no
     mail_access_groups = mail
     protocols = imap
-    mail_location = mbox:~/Mail:INBOX=/var/spool/mail/%u
+    # mail_location = mbox:~/Mail:INBOX=/var/spool/mail/%u
+    mail_driver = mbox
+    mail_path = ~/Mail
+    mail_inbox_path = /var/spool/mail/%{user}
     mail_debug = no
 
     first_valid_uid = 300
-    passdb {
+    passdb dovecot {
       driver = ldap
       args = /etc/dovecot/dovecot-ldap.conf
     }
-    userdb {
+    userdb dovecot {
       driver = passwd
     }
     service auth {
@@ -37,9 +41,11 @@ data:
         ssl = yes
       }
     }
-    ssl_cert = </etc/ssl/certs/smtpd-cert.pem
-    ssl_key = </etc/ssl/private/smtpd-key.pem
-    ssl_min_protocol = TLSv1.1
+    # ssl_cert = </etc/ssl/certs/smtpd-cert.pem
+    # ssl_key = </etc/ssl/private/smtpd-key.pem
+    ssl_min_protocol = TLSv1.2
+    ssl_server_cert_file = /etc/ssl/certs/smtpd-cert.pem
+    ssl_server_key_file = /etc/ssl/private/smtpd-key.pem
     syslog_facility = "local1"
   dovecot-ldap.conf: |
     hosts = {{ .Values.ldap.hosts }}

--- a/images/weewx/helm-nginx/Chart.yaml
+++ b/images/weewx/helm-nginx/Chart.yaml
@@ -5,8 +5,8 @@ home: https://github.com/instantlinux/docker-tools
 sources:
 - https://github.com/instantlinux/docker-tools
 type: application
-version: 0.1.4
-appVersion: "1.27.3-alpine"
+version: 0.1.5
+appVersion: "1.29.3-alpine"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/grafana/Chart.yaml
+++ b/k8s/helm/grafana/Chart.yaml
@@ -6,17 +6,17 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/grafana/grafana
 type: application
-version: 0.1.2
-appVersion: 12.4.0
+version: 0.1.3
+appVersion: 12.3.1
 dependencies:
 - name: chartlib
   version: 0.1.8
   repository: https://instantlinux.github.io/docker-tools
 - name: prometheus
-  version: 0.1.2
+  version: 0.1.3
   repository: file://subcharts/prometheus
   condition: prometheus.enabled
 - name: alertmanager
-  version: 0.1.0
+  version: 0.1.1
   repository: file://subcharts/alertmanager
   condition: alertmanager.enabled

--- a/k8s/helm/grafana/subcharts/alertmanager/Chart.yaml
+++ b/k8s/helm/grafana/subcharts/alertmanager/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://hub.docker.com/r/prom/alertmanager
 type: application
-version: 0.1.0
-appVersion: "v0.28.1"
+version: 0.1.1
+appVersion: "v0.30.1"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/grafana/subcharts/prometheus/Chart.yaml
+++ b/k8s/helm/grafana/subcharts/prometheus/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://hub.docker.com/r/prom/prometheus
 type: application
-version: 0.1.2
-appVersion: "v3.8.0"
+version: 0.1.3
+appVersion: "v3.9.1"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/synapse/subcharts/element/templates/configmap.yaml
+++ b/k8s/helm/synapse/subcharts/element/templates/configmap.yaml
@@ -33,7 +33,13 @@ data:
         "bug_report_endpoint_url": "https://element.io/bugreports/submit",
         "defaultCountryCode": "{{ .Values.country_code }}",
         "show_labs_settings": false,
-        "features": { },
+        "features": {
+            "feature_video_rooms": false,
+            "feature_new_room_decoration_ui": true,
+            "feature_group_calls": false,
+            "feature_element_call_video_rooms": false,
+            "feature_use_device_session_member_events": true
+        },
         "default_federate": true,
         "default_theme": "light",
         "room_directory": {
@@ -48,5 +54,29 @@ data:
         },
         "jitsi": {
             "preferred_domain": "meet.element.io"
+        },
+        "element_call": {
+            "url": "{{ .Values.call.widget_url }}",
+            "participant_limit": 8,
+            "brand": "Element Call",
+            "use_exclusively": true
         }
     }
+  client: |
+    {
+        "default_server_config": {
+            "m.homeserver": {
+                "base_url": "{{ .Values.homeserver_url }}",
+                "server_name": "{{ .Values.server_name }}"
+            },
+            "m.identity_server": {
+                "base_url": "https://vector.im"
+            }
+        },
+        "org.matrix.msc4143.rtc_foci": [{
+            "type": "livekit",
+            "livekit_service_url": "{{ .Values.call.livekit_service_url }}"
+        }]
+    }
+  element.json: |
+    {"call": {"widget_url": "{{ .Values.call.widget_url }}" }}

--- a/k8s/helm/synapse/subcharts/element/values.yaml
+++ b/k8s/helm/synapse/subcharts/element/values.yaml
@@ -1,4 +1,7 @@
 # Default values for element.
+call:
+  livekit_service_url: https://livekit.example.com
+  widget_url: https://call.element.io
 country_code: US
 homeserver_url: https://synapse.example.com
 room_directory_servers: [ "\"matrix.org\"" ]
@@ -16,6 +19,14 @@ volumeMounts:
   name: config
   readOnly: true
   subPath: config.json
+- mountPath: /app/.well-known/matrix/client
+  name: config
+  readOnly: true
+  subPath: client
+- mountPath: /app/.well-known/element/element.json
+  name: config
+  readOnly: true
+  subPath: element.json
 volumes:
 - name: config
   configMap:

--- a/k8s/helm/synapse/values.yaml
+++ b/k8s/helm/synapse/values.yaml
@@ -17,7 +17,11 @@
   # chart makes it easy to just start with postgres.
   #
   # Specify an override:
-  #   deployment.command: startup.py generate
+  #   deployment.command:
+  #   - /bin/sh -c
+  #   - >
+  #     cp /config/homeserver.yaml /data/homeserver.yaml &&
+  #     /start.py generate
   # The synapse pod will then contain a /data/homeserver.yaml
   # with generated secrets from which you can add three more
   # keys to your secret:
@@ -100,7 +104,6 @@ deployment:
     - -c
     - >
       apk add envsubst &&
-      env > /config/vars &&
       for file in $(find /templates -type f -exec basename {} \;); do
        envsubst < /templates/$file > /config/$file;
       done
@@ -186,6 +189,18 @@ element:
   # No separate ingress; use the top-level synapse ingress
   ingress:
     enabled: false
+
+nginx:
+  # Enable this to serve .well-known service discovery on top-level
+  # FQDN if Synapse runs on a subdomain like matrix.example.com
+  enabled: false
+  tlsHostname: example.com
+  deployment:
+    env:
+      country_code: US
+      homeserver_url: https://synapse.example.com
+      room_directory_servers: [ matrix.org ]
+      server_name: My matrix instance
 
 postgres:
   enabled: false


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Add reconnect parameters for kea database
* Update grafana helm chart to `12.3.1`
* Minor updates to (still experimental) synapse helm chart
* Update weewx nginx 

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Defaults for kea cause the server to go offline whenever a packet is lost: the image now contains much better overridden values.

There was a botched edit in the grafana helm chart; also updated subcharts to current version.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing and CI
## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
