### PR TITLE
SYS-674 skip an unremediated CVE in mythbackend

### DIFF
--- a/.image-gitlab-ci.yml
+++ b/.image-gitlab-ci.yml
@@ -51,10 +51,12 @@ security_scan_trivy:
     TRIVY_IGNORE: >-
       CVE-2023-31484,CVE-2023-45853,
       CVE-2023-52425,CVE-2024-8176,
+      CVE-2025-9900,
       CVE-2026-0861,CVE-2025-8194,CVE-2025-13699,
       CVE-2025-13836,CVE-2025-40914
       # Above two rows are for spamassassin under debian trixie
-      # Below were for blacklist image, there's a won't-fix note for zlib1g
+      # CVE-2025-9900 is for MythTV 36
+      # Below are for blacklist image, there's a won't-fix note for zlib1g
       # CVE-2023-31484,CVE-2023-45853
     TRIVY_OUTPUT: gl-container-scanning-report.json
     TRIVY_SEVERITY: HIGH,CRITICAL

--- a/ansible/roles/mythfrontend/defaults/main.yml
+++ b/ansible/roles/mythfrontend/defaults/main.yml
@@ -260,9 +260,11 @@ ubuntu_apt_keys:
   #  and in /etc/apt/sources.list.d/google-chrome.list:
   #    deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main
   #
+  # An alternative approach, until Ansible docs explain a better way, is
+  #  described here: https://peateasea.de/avoiding-ansible-apt-key-on-debian/
+  #
   # chrome: 78BD65473CB3BD13
   graphics: FCAE110B1118213C
-  mythbuntu: 13551B881504888C
 
 ubuntu_packages:
   - cron
@@ -275,6 +277,7 @@ ubuntu_packages:
   - mythtv-common
   - mythtv-frontend
   - kde-plasma-desktop
+  - software-properties-common
   - xserver-xorg-core
   - xserver-xorg-input-all
   - xterm
@@ -293,8 +296,6 @@ ubuntu_repo_defaults:
 
 ubuntu_repo_additions:
   - deb http://ppa.launchpad.net/graphics-drivers/ppa/ubuntu {{
-    ansible_distribution_release }} main
-  - deb http://ppa.launchpad.net/mythbuntu/{{ mythtv_version }}/ubuntu {{
     ansible_distribution_release }} main
   - deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main
 

--- a/ansible/roles/mythfrontend/tasks/debian/packages.yml
+++ b/ansible/roles/mythfrontend/tasks/debian/packages.yml
@@ -1,7 +1,11 @@
 ---
 # packages-ubuntu.yml
 
-- name: Import repository keys
+- name: Add the mythtv repo
+  ansible.builtin.apt_repository:
+    repo: ppa:mythbuntu/{{ mythtv_version }}
+
+- name: Import repository keys for additional repos
   apt_key:
     id: "{{ item.value }}"
     keyserver: keyserver.ubuntu.com

--- a/images/mythtv-backend/Dockerfile
+++ b/images/mythtv-backend/Dockerfile
@@ -7,8 +7,7 @@ LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url=https://github.com/instantlinux/docker-tools
 
-ENV APACHE_LOG_DIR=/var/log/apache2 \
-    DBNAME=mythtv \
+ENV DBNAME=mythtv \
     DBSERVER=db00 \
     DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.UTF-8 \
@@ -35,18 +34,16 @@ RUN \
     curl iputils-ping less lsb-release mariadb-client net-tools \
     mythtv-backend=$MYTHTV_VERSION \
     mythtv-common=$MYTHTV_VERSION mythtv-transcode-utils=$MYTHTV_VERSION \
-    libmyth-python libmythtv-perl php-mythtv php8.3 psmisc \
-    sudo tzdata v4l-utils vim w3m x11-utils xauth xmltv xterm
+    libmyth-python libmythtv-perl psmisc sudo tzdata v4l-utils vim xmltv
 
 COPY src/ /root/
 
 RUN \
   usermod -u $MYTHTV_UID -s /bin/bash mythtv && \
-  mkdir -p /var/lib/mythtv $APACHE_LOG_DIR && \
+  mkdir -p /var/lib/mythtv && \
   echo "mythtv:mythtv" | chpasswd && \
   chown $MYTHTV_UID:$MYTHTV_GID /var/lib/mythtv && \
   ln -s /usr/share/doc/mythtv-backend/contrib/user_jobs/mythlink.pl /usr/bin
 
 EXPOSE 5000/udp 5002/udp 5004/udp 6543 6544 6549 65001 65001/udp 
-VOLUME $APACHE_LOG_DIR
 ENTRYPOINT ["/root/entrypoint.sh"]

--- a/images/mythtv-backend/helm/Chart.yaml
+++ b/images/mythtv-backend/helm/Chart.yaml
@@ -7,7 +7,7 @@ sources:
 - https://github.com/mythtv/mythtv
 type: application
 version: 0.1.18
-appVersion: "36.0-fixes.202602111500.0bcc85b590
+appVersion: "36.0-fixes.202602111500.0bcc85b590"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/mythtv-backend/helm/values.yaml
+++ b/images/mythtv-backend/helm/values.yaml
@@ -88,8 +88,11 @@ authelia:
   fqdn: authtotp.example.com
   ip: 10.101.1.5
 ingress:
-  enabled: true
-  # className: ""
+  # This ingress exposes your MythTV schedule and operational controls to
+  #  the public Internet.
+  # TODO: change default back to true once the setup wizard screens
+  #  are secured by the authentication framework.
+  enabled: false
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/ingress.class: nginx

--- a/images/mythtv-backend/src/entrypoint.sh
+++ b/images/mythtv-backend/src/entrypoint.sh
@@ -7,12 +7,9 @@ localedef -i $(cut -d. -f1 <<< $LANGUAGE) -f $(cut -d. -f2 <<< $LANGUAGE) $LANG
 
 if [ "$OSTYPE" == "opensuse" ]; then
   ln -fns /usr/share/zoneinfo/$TZ /etc/localtime
-  CONF_DIR=/etc/apache2/conf.d
 elif [ "$OSTYPE" == "ubuntu" ]; then
   if [[ $(cat /etc/timezone) != $TZ ]]; then
     echo $TZ > /etc/timezone
-    DIR=/etc/php/$(php -v|grep PHP | grep -oP "\\d+\.\\d+" | head -1)
-    echo "date.timezone = $TZ" > $DIR/cli/conf.d/50-tz.ini
     dpkg-reconfigure -f noninteractive tzdata
   fi
 fi

--- a/k8s/Makefile.helm
+++ b/k8s/Makefile.helm
@@ -12,7 +12,8 @@ helm_list:
 	@helm list --time-format="Mon Jan 2 15:04" --all-namespaces \
 	  --kube-context=sudo
 
-$(CHARTS):: %: helm/%/Chart.lock
+# TODO retire values.yaml
+$(CHARTS):: %: ../admin/services/values.yaml helm/%/Chart.lock
 	@echo --$(NOTICE) $@--
 ifeq ($(ACTION), delete)
 	@helm uninstall --kube-context=sudo -n $(K8S_NAMESPACE) $@
@@ -25,7 +26,7 @@ endif
 
 # TODO this is identical to above but for subdir, DRY it out
 #   the helmify project is just too exhausting
-$(INSTANCES):: %: helm/instances/%/Chart.lock
+$(INSTANCES):: %: ../admin/services/values.yaml helm/instances/%/Chart.lock
 	@echo --$(NOTICE) $@--
 ifeq ($(ACTION), delete)
 	@helm uninstall --kube-context=sudo -n $(K8S_NAMESPACE) $@

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -144,10 +144,16 @@ ansible-playbook k8s-cplane.yml
 Kubernetes should be up and running at this point, with a bare-minimum
 configuration.
 
-Set up a local repo to define environment variables. Kubernetes resources
-here are defined in the native YAML format but with one extension: they
-are parameterized by the use of _envsubst_ which allows values to be
-passed in as shell environment variables in the form $VARIABLE_NAME.
+Set up a local admin repo to define helm overrides and environment variables, git-cloned under the path ~/docker/k8s/admin. Within the admin repo, create a subdirectory `services` with a file `values.yaml` containing any site-specific overrides, such as:
+```
+authelia
+  fqdn: authtotp.mydomain.com
+domain: mydomain.com
+serviceAccount:
+  name: instantlinux-privileged
+tz: America/Los_Angeles
+```
+Under a `services/values` subdirectory, put each of your chartname.yaml files with the override settings you need.
 
 Set a symlink from a directory under this one (k8s/secrets) to a
 subdirectory in your local administrative repo. This is where you will

--- a/k8s/helm/restic/Chart.yaml
+++ b/k8s/helm/restic/Chart.yaml
@@ -6,10 +6,10 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/restic/restic
 type: application
-version: 0.1.22
+version: 0.1.23
 # Remember to update restic==<ver> in values.yaml as releases are published;
 #  the values.yaml file is not able to reference .Chart.appVersion
-appVersion: "0.18.1-r3"
+appVersion: "0.18.1-r4"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/restic/values.yaml
+++ b/k8s/helm/restic/values.yaml
@@ -17,7 +17,7 @@ deployment:
     mkdir -p /var/log/week && tail -f -n 0 /var/log/restic.log
   env:
     # Edit the version in Chart.yaml to keep consistent
-    app_version: 0.18.1-r3
+    app_version: 0.18.1-r4
     env: /etc/profile
     tz: UTC
   nodeSelector:


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Add CVE-2025-9900 to the ignore list of trivy
* Rip out the rest of apache and php from the mythtv-backend image
* Bump restic helm chart to `0.18.1-r4`

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
First one thing. Then another. Then another damn problem. This time it was CVE-2025-9900, a high-sev CVE in ubuntu noble out there for several months without any fix available. MythTV version 36 switched over since version 35 to libqt5webengine, where this vulnerability resides.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
