### PR TITLE
nut-upsd: Add pollonly option to entrypoint script

### DIFF
--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -22,6 +22,7 @@ ENV ACTIONS= \
     NUT_QUIET_INIT_SSL=true \
     NUT_QUIET_INIT_UPSNOTIFY=true \
     POLLINTERVAL= \
+    POLLONLY= \
     PORT=auto \
     SDORDER= \
     SECRETNAME=nut-upsd-password \

--- a/images/nut-upsd/Dockerfile.arm32
+++ b/images/nut-upsd/Dockerfile.arm32
@@ -15,6 +15,7 @@ ENV API_USER=upsmon \
     GROUP=nut \
     NAME=ups \
     POLLINTERVAL= \
+    POLLONLY= \
     PORT=auto \
     SDORDER= \
     SECRET=nut-upsd-password \

--- a/images/nut-upsd/Dockerfile.arm64
+++ b/images/nut-upsd/Dockerfile.arm64
@@ -15,6 +15,7 @@ ENV API_USER=upsmon \
     GROUP=nut \
     NAME=ups \
     POLLINTERVAL= \
+    POLLONLY= \
     PORT=auto \
     SDORDER= \
     SECRET=nut-upsd-password \

--- a/images/nut-upsd/README.md
+++ b/images/nut-upsd/README.md
@@ -52,6 +52,7 @@ NUT_DEBUG_LEVEL | 0 | verbosity of debug messages
 NUT_QUIET_INIT_SSL | true | inhibit superfluous startup warning
 NUT_QUIET_INIT_UPSNOTIFY | true | inhibit superfluous startup warning
 POLLINTERVAL | | Poll Interval for ups.conf
+POLLONLY | | Disable USB interrupt reads
 PORT | auto | device port (e.g. /dev/ttyUSB0) on host
 SDORDER | | UPS shutdown sequence, set to -1 to disable shutdown
 SECRETNAME | nut-upsd-password | name of secret to use for API user

--- a/images/nut-upsd/entrypoint.sh
+++ b/images/nut-upsd/entrypoint.sh
@@ -23,6 +23,9 @@ EOF
     if [ ! -z "$POLLINTERVAL" ]; then
       echo "        pollinterval = $POLLINTERVAL" >> /etc/nut/ups.conf
     fi
+    if [ ! -z "$POLLONLY" ]; then
+      echo "        pollonly" >> /etc/nut/ups.conf
+    fi
     if [ ! -z "$VENDORID" ]; then
       echo "        vendorid = $VENDORID" >> /etc/nut/ups.conf
     fi


### PR DESCRIPTION
## Summary of Changes

Adds a new optional environment variable, `POLLONLY`, to the Docker image for Network UPS Tools (NUT) . Following the same conventions as other options in the entrypoint script, when set, it appends `pollonly` to the generated `ups.conf`.

Closes #264.

## Why is this change being made?

`pollonly` disables USB interrupt-based reads in favor of direct HID polling, and is particularly useful for CyberPower UPS devices whose HID implementations don't reliably send USB interrupt reports. Without it, the `usbhid-ups` driver stalls waiting for reports that never arrive, eventually marking data as stale and causing the UPS to appear offline.

## How was this tested? How can the reviewer verify your testing?

Tested by building the image directly from the branch using a `docker-compose.yml` with:

```yaml
  build:
    context: https://github.com/RyanGWU82/docker-tools.git#nut-upsd/pollonly:images/nut-upsd
```

To verify independently, a reviewer can build and run the container with `POLLONLY` set and inspect the generated config. The output should include `pollonly` in the `[ups]` block.

```sh
# Build a test image from my branch
docker build https://github.com/RyanGWU82/docker-tools.git#nut-upsd/pollonly:images/nut-upsd -t nut-upsd-test

# Start a container with POLLONLY set
docker run -d --name nut-upsd-test -e POLLONLY=1 nut-upsd-test

# Verify that pollonly appears in the generated ups.conf
docker exec nut-upsd-test cat /etc/nut/ups.conf

# Clean up
docker rm -f nut-upsd-test
```

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
