### PR TITLE
SYS-684 upgrades kubernetes 1.35.3, restic 0.18.1-r5

### DIFF
--- a/ansible/roles/docker_node/handlers/main.yml
+++ b/ansible/roles/docker_node/handlers/main.yml
@@ -15,7 +15,7 @@
 
 - name: Restart sshd
   service:
-    name: sshd
+    name: ssh
     state: restarted
 
 - name: Reload systemd

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -13,9 +13,9 @@ k8s_defaults:
   admin_config: /etc/kubernetes/admin.conf
   config_fetch_always: false
   apt_repo:
-    # TODO parameterize hardcoded 1.34 value
-    repo: deb [signed-by=/etc/apt/keyrings/kubernetes.asc] https://pkgs.k8s.io/core:/stable:/v1.34/deb/ /
-    url: https://pkgs.k8s.io/core:/stable:/v1.34/deb/Release.key
+    # TODO parameterize hardcoded 1.35 value
+    repo: deb [signed-by=/etc/apt/keyrings/kubernetes.asc] https://pkgs.k8s.io/core:/stable:/v1.35/deb/ /
+    url: https://pkgs.k8s.io/core:/stable:/v1.35/deb/Release.key
   cplane_hostip: "{{ hostvars[groups['k8s_cplane'][0]]['ansible_default_ipv4']['address'] | default(groups['k8s_cplane'][0]) }}"
   cplane_vip: "{{ hostvars[groups['k8s_cplane'][0]]['ansible_default_ipv4']['address'] | default(groups['k8s_cplane'][0]) }}"
   # TODO: might be able to retire cri-dockerd
@@ -26,15 +26,14 @@ k8s_defaults:
   local_vols: /var/lib/docker/k8s-volumes
   cplane: False
   pod_network: 10.244.0.0/16
-  pod_infra_container_image: registry.k8s.io/pause:3.10.1
   service:
     enabled: yes
     name: kubelet
     state: restarted
   service_network: 10.96.0.0/12
-  version: 1.34.3
-  coredns_version: v1.11.3
-  cni_version: 1.7.1
+  version: 1.35.3
+  coredns_version: v1.13.1
+  cni_version: 1.8.0
 k8s_override: {}
 k8s: "{{ k8s_defaults | combine(k8s_override) }}"
 

--- a/ansible/roles/kubernetes/tasks/cplane.yml
+++ b/ansible/roles/kubernetes/tasks/cplane.yml
@@ -37,19 +37,19 @@
 # TODO - sed s/kubernetes/{{hostname -s}}/g
 
 - name: Symlink .kube/admin.conf
-  local_action:
-    module: file
+  ansible.builtin.file:
     src:  "{{ admin_conf_dest }}"
     dest: /home/{{ username.stdout }}/.kube/admin.conf
     state: link
+  delegate_to: localhost
   when: not kubeadm_ca.stat.exists or k8s.config_fetch_always
 
 - name: Symlink .kube/config
-  local_action:
-    module: file
+  ansible.builtin.file:
     src:  "{{ admin_conf_dest }}"
     dest: /home/{{ username.stdout }}/.kube/config
     state: link
+  delegate_to: localhost
   when: not kubeadm_ca.stat.exists or k8s.config_fetch_always
 
 - name: Create kubelet service override directory

--- a/ansible/roles/kubernetes/tasks/cri-dockerd.yml
+++ b/ansible/roles/kubernetes/tasks/cri-dockerd.yml
@@ -32,8 +32,7 @@
       --network-plugin=cni \
       --cni-bin-dir=/opt/cni/bin \
       --cni-cache-dir=/var/lib/cni/cache \
-      --cni-conf-dir=/etc/cni/net.d \
-      --pod-infra-container-image={{ k8s.pod_infra_container_image }}
+      --cni-conf-dir=/etc/cni/net.d
 
 - name: Enable cri-docker.service
   ansible.builtin.systemd:

--- a/k8s/helm/restic/Chart.yaml
+++ b/k8s/helm/restic/Chart.yaml
@@ -6,10 +6,10 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/restic/restic
 type: application
-version: 0.1.23
+version: 0.1.24
 # Remember to update restic==<ver> in values.yaml as releases are published;
 #  the values.yaml file is not able to reference .Chart.appVersion
-appVersion: "0.18.1-r4"
+appVersion: "0.18.1-r5"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/restic/values.yaml
+++ b/k8s/helm/restic/values.yaml
@@ -17,7 +17,7 @@ deployment:
     mkdir -p /var/log/week && tail -f -n 0 /var/log/restic.log
   env:
     # Edit the version in Chart.yaml to keep consistent
-    app_version: 0.18.1-r4
+    app_version: 0.18.1-r5
     env: /etc/profile
     tz: UTC
   nodeSelector:


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Upgrade kubernetes from `1.34.x` to `1.35.3`
* Upgrade restic helm chart to `0.18.1-r5`
* Eliminate deprecated references to `--pod-infra-container-image`
* Adjust some outdated ansible directives

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Routine dependency updates 

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing and CI

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
