### PR TITLE
SYS-686 mythtv-backend and mariadb-galera image updates

### DIFF
--- a/images/mariadb-galera/Dockerfile
+++ b/images/mariadb-galera/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:12.1.2
+FROM mariadb:12.3.1
 ARG BUILD_DATE
 ARG VCS_REF
 LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \

--- a/images/mariadb-galera/helm/Chart.yaml
+++ b/images/mariadb-galera/helm/Chart.yaml
@@ -7,8 +7,8 @@ sources:
 - https://github.com/MariaDB/server
 - https://github.com/MariaDB/galera
 type: application
-version: 0.1.2
-appVersion: "12.1.2"
+version: 0.1.3
+appVersion: "12.3.1"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/mariadb-galera/requirements/test.txt
+++ b/images/mariadb-galera/requirements/test.txt
@@ -1,5 +1,5 @@
-coverage==7.11.0
+coverage==7.13.5
 flake8==7.3.0
 mock==5.2.0
-pytest==8.4.2
-pytest-cov==7.0.0
+pytest==9.0.3
+pytest-cov==7.1.0

--- a/images/mythtv-backend/Dockerfile
+++ b/images/mythtv-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM ubuntu:resolute
 ARG BUILD_DATE
 ARG VCS_REF
 LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
@@ -19,7 +19,7 @@ ENV DBNAME=mythtv \
 ARG MYTHTV_GID=100
 ARG MYTHTV_UID=2021
 ARG MYTHTV_PPA=ppa:mythbuntu/36
-ARG MYTHTV_VERSION=2:36.0+fixes.202602111500.0bcc85b590~ubuntu24.04.1
+ARG MYTHTV_VERSION=2:36.0+fixes.202604171138.4a9097b492~ubuntu26.04.1
 ARG MYTHLINK_SHA=459cb8b60adae4b631a95a9cfb1b41dcb959cc4a0b9053582a711d58b8d8a0d2
 
 RUN \
@@ -34,7 +34,8 @@ RUN \
     curl iputils-ping less lsb-release mariadb-client net-tools \
     mythtv-backend=$MYTHTV_VERSION \
     mythtv-common=$MYTHTV_VERSION mythtv-transcode-utils=$MYTHTV_VERSION \
-    libmyth-python libmythtv-perl psmisc sudo tzdata v4l-utils vim xmltv
+    libmyth-python libmythtv-perl libjson-xs-perl psmisc sudo tzdata v4l-utils \
+    vim xmltv
 
 COPY src/ /root/
 

--- a/images/mythtv-backend/helm/Chart.yaml
+++ b/images/mythtv-backend/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/mythtv/mythtv
 type: application
-version: 0.1.19
-appVersion: "36.0-fixes.202602111500.0bcc85b590"
+version: 0.1.20
+appVersion: "36.0-fixes.202604171138.4a9097b492"
 dependencies:
 - name: chartlib
   version: 0.1.8


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
- Add `libjson-xs-perl` for xmltv schedule download efficiency in mythtv image
- Build mythtv-backend under new ubuntu:resolute distro
- Update mariadb-galera image

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Routine vulnerability updates

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing and CI
## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
