### PR TITLE
SYS-686 passkey support to authelia helm chart; update nut-upsd and restic

### DIFF
--- a/images/nut-upsd/Dockerfile
+++ b/images/nut-upsd/Dockerfile
@@ -33,7 +33,7 @@ ENV ACTIONS= \
 HEALTHCHECK CMD upsc $NAME@localhost:3493 2>&1|grep -q stale && \
     killall -TERM upsmon || true
 
-RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/community' \
+RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/main' \
       >>/etc/apk/repositories && \
     apk add --no-cache dash && \
     apk add --update --no-cache nut=$NUT_VERSION \

--- a/k8s/helm/authelia/Chart.yaml
+++ b/k8s/helm/authelia/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/authelia/authelia
 type: application
-version: 0.1.10
-appVersion: "4.39.15"
+version: 0.1.11
+appVersion: "4.39.19"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/authelia/templates/configmap.yaml
+++ b/k8s/helm/authelia/templates/configmap.yaml
@@ -49,6 +49,12 @@ data:
         {{- end }}
         policy: two_factor
 
+    # Webauthn / passkeys
+    webauthn:
+      disable: {{ not .Values.enable_webauthn }}
+      display_name: {{ .Values.display_name }}
+      enable_passkey_login: {{ .Values.enable_passkey }}
+
     # Configuration of session cookies
     session:
       expiration: {{ .Values.session.expiration }}

--- a/k8s/helm/authelia/values.yaml
+++ b/k8s/helm/authelia/values.yaml
@@ -2,7 +2,10 @@
 baseDN: dc=example,dc=com
 bypassDomain: monitor.example.com
 bypassUser: "user:username"
+display_name: Authelia Service
 domains: [ example.com ]
+enable_passkey: true
+enable_webauthn: false
 logLevel: info
 mysql:
   address: tcp://db00:3306

--- a/k8s/helm/restic/Chart.yaml
+++ b/k8s/helm/restic/Chart.yaml
@@ -6,10 +6,10 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/restic/restic
 type: application
-version: 0.1.24
+version: 0.1.25
 # Remember to update restic==<ver> in values.yaml as releases are published;
 #  the values.yaml file is not able to reference .Chart.appVersion
-appVersion: "0.18.1-r5"
+appVersion: "0.18.1-r6"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/restic/values.yaml
+++ b/k8s/helm/restic/values.yaml
@@ -17,7 +17,7 @@ deployment:
     mkdir -p /var/log/week && tail -f -n 0 /var/log/restic.log
   env:
     # Edit the version in Chart.yaml to keep consistent
-    app_version: 0.18.1-r5
+    app_version: 0.18.1-r6
     env: /etc/profile
     tz: UTC
   nodeSelector:


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Add webauthn and passkey params to authelia helm chart
* Bump restic helm chart version
* Another attempt to get nut-upsd image to pass vulnerability scanning
## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Routine dependency updates, and support for new feature in Authelia

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing and CI
## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
