### PR TITLE
SYS-687 ansible updates for Ubuntu 26.04

### DIFF
--- a/ansible/fileserver-setup.yml
+++ b/ansible/fileserver-setup.yml
@@ -15,5 +15,5 @@
   - { role: monitoring_agent, tags: nagios }
   - { role: bind9, tags: bind9 }
   - { role: ntp, tags: ntp }
-  - { role: fileserver, tags: fileserver }
   - { role: volumes, tags: volumes }
+  - { role: fileserver, tags: fileserver }

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,3 +1,3 @@
 ansible==12.3.0
 ansible-lint==26.1.1
-pip==26.0
+pip==26.1

--- a/ansible/roles/docker_node/defaults/main.yml
+++ b/ansible/roles/docker_node/defaults/main.yml
@@ -5,7 +5,7 @@ docker_defaults:
   apt_repo:
     key: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
     package_name: docker-ce
-    package_ver: 5:29.2.0-1~ubuntu.24.04~noble
+    package_ver: 5:29.4.1-1~ubuntu.26.04~resolute
     repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
     url: https://download.docker.com/linux/ubuntu/gpg
   certs:
@@ -31,10 +31,6 @@ docker_defaults:
       max-file: "3"
     min-api-version: "1.43"
     storage-driver: overlay2
-    # storage-opts:
-    # - dm.thinpooldev=/dev/mapper/{{ thinpool_vg_alt }}-thinpool
-    # - dm.use_deferred_removal=false
-    # - dm.use_deferred_deletion=false
     tls: True
     tlscacert: /root/certs/ca-root.pem
     tlscert: /root/certs/docker-tls-cert.pem
@@ -70,6 +66,7 @@ ubuntu_packages:
   - jq
   - libpam-google-authenticator
   - rsync
+  - ssh-askpass
   - snmpd
   - thin-provisioning-tools
   - uuid-runtime

--- a/ansible/roles/fileserver/tasks/instantlinux.yml
+++ b/ansible/roles/fileserver/tasks/instantlinux.yml
@@ -4,6 +4,7 @@
     repo: 'https://git.instantlinux.net/richb/instantlinux.git/'
     dest: /opt/instantlinux
     update: no
+  ignore_errors: true
 
 - name: Link to usr/lib/ilinux
   file:

--- a/ansible/roles/fileserver/templates/smb.conf.j2
+++ b/ansible/roles/fileserver/templates/smb.conf.j2
@@ -1,9 +1,7 @@
 {{ ansible_managed | comment }}
 [global]
         bind interfaces only = yes
-        domain logons = No
         domain master = No
-        encrypt passwords = Yes
         interfaces = {{ samba.interfaces | join(' ') }}
         log level = {{ samba.log_level }}
         logon drive = {{ samba.logon_drive }}:

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -31,7 +31,7 @@ k8s_defaults:
     name: kubelet
     state: restarted
   service_network: 10.96.0.0/12
-  version: 1.35.3
+  version: 1.35.4
   coredns_version: v1.13.1
   cni_version: 1.8.0
 k8s_override: {}

--- a/ansible/roles/kubernetes/tasks/join.yml
+++ b/ansible/roles/kubernetes/tasks/join.yml
@@ -1,4 +1,6 @@
 ---
+# TODO: invoke token create on master to generate token and cert hash
+
 - name: Set kubeadm configuration
   ansible.builtin.copy:
     dest: /etc/kubernetes/kubeadm-config.yaml
@@ -10,6 +12,8 @@
           # Discover host IP rather than service vip, misleading error is:
           #  "could not find a JWS signature in the cluster-info ConfigMap"
           apiServerEndpoint: "{{ k8s.cplane_hostip }}:6443"
+          caCertHashes:
+          - "manually copy from token create --print-join-command"
           token: "{{ vault_k8s.join_token }}"
           unsafeSkipCAVerification: True
       nodeRegistration:
@@ -25,6 +29,7 @@
   register: reset_cluster
   when: not kubeadm_ca.stat.exists
 
+# This will fail because of stale token and hash values
 - name: Join to Kubernetes cluster
   command: kubeadm join --config /etc/kubernetes/kubeadm-config.yaml
   register: join_cluster

--- a/ansible/roles/mythfrontend/tasks/debian/packages.yml
+++ b/ansible/roles/mythfrontend/tasks/debian/packages.yml
@@ -2,32 +2,60 @@
 # packages-ubuntu.yml
 
 - name: Add the mythtv repo
-  ansible.builtin.apt_repository:
-    repo: ppa:mythbuntu/{{ mythtv_version }}
+  ansible.builtin.deb822_repository:
+    name: mythbuntu
+    components: [ main ]
+    suites: "{{ ansible_distribution_release }}"
+    types: [ deb ]
+    uris: https://ppa.launchpadcontent.net/mythbuntu/{{ mythtv_version }}/ubuntu
+    signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x517f4b7559621884dcd9c61960af0ee633670609
+  register: repo1
 
-- name: Import repository keys for additional repos
-  apt_key:
-    id: "{{ item.value }}"
-    keyserver: keyserver.ubuntu.com
-  with_dict: "{{ ubuntu_apt_keys }}"
+- name: Add the graphics drivers repo
+  ansible.builtin.deb822_repository:
+    name: graphics
+    components: [ main ]
+    suites: "{{ ansible_distribution_release }}"
+    types: [ deb ]
+    uris: https://ppa.launchpadcontent.net/graphics-drivers/ppa/ubuntu
+    signed_by: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2388FF3BE10A76F638F80723FCAE110B1118213C
+  register: repo2
 
-- name: Ensure repositories available
-  apt_repository:
-    repo: "{{ item }}"
-    filename: ubuntu
-  with_items: "{{ ubuntu_repos }}"
+- name: Add the google chrome repo
+  ansible.builtin.deb822_repository:
+    name: chrome
+    components: [ main ]
+    suites: stable
+    types: [ deb ]
+    uris: https://dl.google.com/linux/chrome/deb/
+    signed_by: https://dl.google.com/linux/linux_signing_key.pub
+  register: repo3
+
+- name: Ensure ubuntu distro sources are available
+  ansible.builtin.deb822_repository:
+    name: ubuntu
+    components: [ main, restricted, universe, multiverse ]
+    suites:
+    - "{{ansible_distribution_release }}"
+    - "{{ansible_distribution_release }}-updates"
+    - "{{ansible_distribution_release }}-backports"
+    - "{{ansible_distribution_release }}-security"
+    types: [ deb ]
+    uris: http://mirrors.accretive-networks.net/ubuntu/
+    signed_by: /etc/apt/trusted.gpg.d/ubuntu-keyring-2018-archive.gpg
+  register: repo4
 
 - name: Update repository sources
-  apt:
+  ansible.builtin.apt:
     update_cache: yes
-    cache_valid_time: 86400
+  when: repo1.changed or repo2.changed or repo3.changed or repo4.changed
 
 - name: Install system packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ ubuntu_packages }}"
 
 - name: Remove akonadi-dependent packages
-  apt:
+  ansible.builtin.apt:
     autoremove: yes
     name:
     - akonadi-server

--- a/ansible/roles/mythfrontend/tasks/vars/resolute.yml
+++ b/ansible/roles/mythfrontend/tasks/vars/resolute.yml
@@ -1,0 +1,2 @@
+---
+x11_config_path: /usr/share/X11/xorg.conf.d

--- a/ansible/roles/network/defaults/main.yml
+++ b/ansible/roles/network/defaults/main.yml
@@ -15,6 +15,7 @@ network_defaults:
   mode: dhcp
   nameservers: "{{ hostvars[inventory_hostname]['ansible_dns']['nameservers'] }}"
   netmask: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['netmask'] }}"
+  optional: false
   routes:
   - to: default
     via: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['gateway'] }}"

--- a/ansible/roles/network/tasks/netplan.yml
+++ b/ansible/roles/network/tasks/netplan.yml
@@ -5,7 +5,8 @@
         {'network': {'ethernets': {network.interface: {
          'addresses': network.addresses,
          'dhcp4': False,
-         'gateway4': network.gateway,
+         'optional': network.optional,
+         'routes': network.routes,
          'nameservers': {
             'search': ansible_dns.search,
             'addresses': network.nameservers}}}}},

--- a/ansible/roles/ntp/defaults/main.yml
+++ b/ansible/roles/ntp/defaults/main.yml
@@ -12,11 +12,11 @@ ntp_defaults:
   - 2.pool.ntp.org
   service:
     enabled: yes
-    name: "{{ 'ntp' if ansible_os_family == 'Debian' else 'ntpd' }}"
+    name: "{{ 'ntpd-rs' if ansible_os_family == 'Debian' else 'ntpd' }}"
     state: restarted
 
 ntp_override: {}
 ntp: "{{ ntp_defaults | combine(ntp_override) }}"
 
 ubuntu_packages:
-  - ntp
+  - ntpd-rs

--- a/ansible/roles/ntp/tasks/main.yml
+++ b/ansible/roles/ntp/tasks/main.yml
@@ -31,9 +31,31 @@
     dest: /etc/ntpsec/ntp.conf
     src: ntp.conf.j2
   notify: Restart ntpd
-  when: ntp.service.enabled and ansible_distribution_version >= '24.04'
+  when: ntp.service.enabled and ansible_distribution_version == '24.04'
+
+- name: Override directory for ntp-rs systemd unit file
+  file:
+    dest: /etc/systemd/system/ntpd-rs.service.d
+    state: directory
+  when: ntp.service.enabled and ansible_distribution_version >= '26.04'
+
+- name: Allow ntp-rs to bind on port 123
+  copy:
+    dest: /etc/systemd/system/ntpd-rs.service.d/override.conf
+    content: |
+      [Service]
+      AmbientCapabilities=CAP_SYS_TIME CAP_NET_BIND_SERVICE
+  when: ntp.service.enabled and ansible_distribution_version >= '26.04'
+
+- name: ntp-rs config
+  ansible.builtin.template:
+    dest: /etc/ntpd-rs/ntp.toml
+    src: ntp.toml.j2
+  notify: Restart ntpd
+  when: ntp.service.enabled and ansible_distribution_version >= '26.04'
 
 - name: NTP service
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     enabled: "{{ ntp.service.enabled }}"
     name: "{{ ntp.service.name }}"
+    daemon_reload: yes

--- a/ansible/roles/ntp/templates/ntp.toml.j2
+++ b/ansible/roles/ntp/templates/ntp.toml.j2
@@ -1,0 +1,26 @@
+{{ ansible_managed | comment }}
+[observability]
+log-level = "info"
+observation-path = "/var/run/ntpd-rs/observe"
+
+{% if 'servers' in ntp %}
+{% for server in ntp.servers %}
+[[source]]
+mode = "server"
+address = "{{ server }}"
+{% endfor %}
+{% endif %}
+{% if 'pool' in ntp %}
+{% for server in ntp.pool %}
+[[source]]
+mode = "pool"
+address = "{{ server }}"
+count = 4
+{% endfor %}
+{% endif %}
+
+[[server]]
+listen = "0.0.0.0:123"
+
+[synchronization]
+single-step-panic-threshold = 1800


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Ubuntu 26.04 came out. Here are the changes to support ansible playbooks here (k8s-node, fileserver and mythfrontend):

* docker and k8s versions bumped
* ssh-askpass added to k8s-node for use with `git commit`
* got rid of another case where ansible was still using `apt_key` and `apt_repository` (now `ansible.builtin.deb822_repository`)
* got rid of another case of deprecated `gateway4` in netplan (now `routes`)
* replaced ntp with ntpd-rs
## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
The usual pile of deprecations broke several things. This brings the repo into more or less full compliance with Ubuntu's standards for this LTS release, to make dependency updates easier next couple of years.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
