### PR TITLE
SYS-687 device-exclude option for check_drive_health

### DIFF
--- a/ansible/roles/fileserver/tasks/qemu.yml
+++ b/ansible/roles/fileserver/tasks/qemu.yml
@@ -1,6 +1,6 @@
 ---
 - name: QEMU virt-manager package
-  ansbile.builtin.package:
+  ansible.builtin.package:
     name: virt-manager
 
 - name: DBUS package to support virt-manager dconf under X11

--- a/ansible/roles/monitoring_agent/files/plugins/check_drive_health.py
+++ b/ansible/roles/monitoring_agent/files/plugins/check_drive_health.py
@@ -73,6 +73,9 @@ SMART_ATTR_CHECKS = {
                    'device serial number, in YAML format')
 @click.option('--raid/--no-raid', default=True,
               help='Examine RAID devices found in /proc/mdstat [true]')
+@click.option('--exclude', '-x',
+              type=str, multiple=True,
+              help='Exclude device')
 @click.option('--warn-temp', '-w', default=50,
               type=int,
               help='Temperature warning threshold [50]')
@@ -82,11 +85,13 @@ SMART_ATTR_CHECKS = {
 @click.option('--warn-spare', default=50,
               type=int,
               help='Spare-percentage warning threshold for nvme [50]')
-def main(device, error_list, raid, warn_temp, crit_temp, warn_spare):
+def main(device, error_list, raid, exclude, warn_temp, crit_temp, warn_spare):
     if 'all' in device:
         # Get all block storage devices except loopback (major=7)
         device = [item['name'] for item in
                   json.load(os.popen('lsblk -dJ -e 7'))['blockdevices']]
+    exclude = [item.removeprefix('/dev/') for item in exclude]
+    device = [item for item in device if item not in exclude]
     error_items = yaml.safe_load(error_list) if error_list else {}
     retval, messages = STATUS_OK, ([], [], [], [])
     for drive in device:

--- a/ansible/roles/monitoring_agent/tasks/packages.yml
+++ b/ansible/roles/monitoring_agent/tasks/packages.yml
@@ -1,50 +1,19 @@
 ---
 # packages.yml
 
-- name: Zypper repositories
-  command: zypper addrepo {{ item.repo }} {{ item.name }}
-  args:
-    creates: /etc/zypp/repos.d/{{ item.name}}.repo
-  with_items: "{{ opensuse_repos }}"
-  when: ansible_os_family == 'Suse'
-
 - name: Install system packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ ubuntu_packages }}"
-  when: ansible_os_family == 'Debian'
 
 - name: Install extra packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ ubuntu_packages_extra }}"
   when: ansible_distribution_version >= '18.04'
 
-- name: Install system packages
-  zypper:
-    name: "{{ opensuse_packages }}"
-  when: ansible_os_family == 'Suse'
-
-- name: Minimum version 7.x smartmontools
-  shell: |
-    set -e
-    wget -O /tmp/smart.tar.gz https://downloads.sourceforge.net/project/smartmontools/smartmontools/{{
-      smartmon_download.version}}/smartmontools-{{smartmon_download.version}}.tar.gz
-    echo "{{ smartmon_download.checksum }}  /tmp/smart.tar.gz" | shasum -c
-    tar xf /tmp/smart.tar.gz -C /tmp
-    chdir /tmp/smartmontools-{{ smartmon_download.version }}
-    ./configure && make install
-    rm -r /tmp/smart.tar.gz /tmp/smartmontools-{{ smartmon_download.version }}
-  args:
-    creates: /usr/local/sbin/smartctl
-  when: ansible_distribution_version < '20.04'
-
 - name: Python packages for monitoring
-  command: pip3 install --break-system-packages {{ pip_packages|join(' ') }}
+  ansible.builtin.command: pip3 install --break-system-packages {{
+    pip_packages|join(' ') }}
   args:
-    creates: /usr/local/lib/python3.12/dist-packages/mdstat
-  when: ansible_distribution_version >= '24.04'
-
-- name: Python packages for monitoring
-  command: pip3 install {{ pip_packages|join(' ') }}
-  args:
-    creates: /usr/local/lib/python3.10/dist-packages/mdstat
-  when: ansible_distribution_version < '24.04'
+    creates: /usr/local/lib/python{{
+      ansible_python.version.major }}.{{ ansible_python.version.minor
+      }}/dist-packages/mdstat


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Provide an option to skip devices in check_drive_health nagios monitor
* Fix a typo in #278 qemu installer task
* Clean out old pre-24.04 and Suse references from monitoring_agent packages task
## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
If USB thumb drive is inserted into a system being monitored, the smartctl command (usually) fails and produces an error like this:
```
UNK(/dev/sdf): /dev/sdf: Unknown USB bridge [0x0951:0x16d5 (0x100)]
```
This enhancement allows such a device to be ignored, at least if it has a consistent device name.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing
## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
