### PR TITLE
fix: unexpected exit when adduser failed in vsftpd image

### DIFF
--- a/images/vsftpd/entrypoint.sh
+++ b/images/vsftpd/entrypoint.sh
@@ -13,7 +13,9 @@ if [ -z "$PASV_ADDRESS" ]; then
 fi
 
 if [ -e /run/secrets/$FTPUSER_PASSWORD_SECRET ]; then
-  adduser -u $FTPUSER_UID -s /bin/sh -g "ftp user" -D $FTPUSER_NAME
+  if ! id "$FTPUSER_NAME" >/dev/null 2>&1; then
+    adduser -u $FTPUSER_UID -s /bin/sh -g "ftp user" -D $FTPUSER_NAME
+  fi
   echo "$FTPUSER_NAME:$(cat /run/secrets/$FTPUSER_PASSWORD_SECRET)" \
     | chpasswd -e
 fi


### PR DESCRIPTION
## Summary of Changes

run adduser only when user is not exists in vsftpd image

## Why is this change being made?

I use vsftpd image by create a normal docker container,
when restart the container,
container will failed at every restart and shows `adduser: user 'ftpuser' in use` in docker logs,
then it just stopped itself.

this fix will run `adduser` in only when the container does not have that user in `entrypoint.sh`.

## How was this tested? How can the reviewer verify your testing?

1. prepare `ftp-user-password-secret` file described in README.md
2. `docker run --name vsftpd -d -e PASV_ADDRESS=172.17.0.1 -v ./ftp-user-password-secret:/run/secrets/ftp-user-password-secret:ro instantlinux/vsftpd`
3. docker restart vsftpd

## Completion checklist

- [ ] The pull request is linked to all related issues
- [ ] This change has unit test coverage
- [ ] Documentation has been updated
- [x] Dependencies have been updated and verified
