### PR TITLE
SYS-695 add zstd support (for compression) to mysqldump image

### DIFF
--- a/images/mysqldump/Dockerfile
+++ b/images/mysqldump/Dockerfile
@@ -9,6 +9,9 @@ LABEL org.opencontainers.image.authors="Rich Braun docker@instantlinux.net" \
 
 ENV HOUR=3 MINUTE=30 \
     KEEP_DAYS=31 \
+    COMPRESS=zstd \
+    COMPRESSLEVEL=5 \
+    COMPRESSOPTS="--rm -fq" \
     DB_CREDS_SECRETNAME=mysql-backup-creds \
     LOCK_FOR_BACKUP= \
     SERVERS=dbhost \
@@ -25,7 +28,7 @@ RUN RMGROUP=$(grep :$BACKUP_GID: /etc/group | cut -d: -f 1) && \
     addgroup -g $BACKUP_GID backup && \
     adduser -u $UID -G backup -s /bin/sh -g "MariaDB" -D $USERNAME && \
     apk add --update --no-cache \
-     bzip2 dcron mariadb-client=$CLIENT_VERSION tzdata && \
+     zstd dcron mariadb-client=$CLIENT_VERSION tzdata && \
     rm -fr /var/cache/apk/* /var/log/*
 
 COPY *.sh /usr/local/bin/

--- a/images/mysqldump/README.md
+++ b/images/mysqldump/README.md
@@ -86,7 +86,7 @@ data:
 
 ### Notes
 
-Successful completion of dumps is indicated by updates to the file `mysqldump-status.txt`: if that file's age exceeds 24+ hours, look for failures. If the dump files are complete but storage rapidly runs out because `zstd` or `bzip2` didn't run, run the script manually (using the commands seen in `crontab -l -u mysqldump` from a root shell within the container) and check for errors such as the following:
+Successful completion of dumps is indicated by updates to the file `mysqldump-status.txt`: if that file's age exceeds 24+ hours, look for failures. If the dump files are complete but storage rapidly runs out because `zstd` or `bzip2` didn't run, run the script manually (using the commands seen in `crontab -l -u mysqldump` from a `su - mysqldump` shell within the container) and check for errors such as the following:
 ```
 mariadb-dump: Got error: 1044: "Access denied for user 'bkp'@'%' to database 'rsnap'" when using LOCK TABLES
 mariadb-dump: Couldn't execute 'show events': Access denied for user 'bkp'@'%' to database 'rsnap' (1044)

--- a/images/mysqldump/README.md
+++ b/images/mysqldump/README.md
@@ -51,6 +51,9 @@ make mysqldump
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
+| COMPRESS | zstd | command: zstd or bzip2 |
+| COMPRESSLEVEL | 5 | compression level |
+| COMPRESSOPTS | --rm -fq | options for compression |
 | DB_CREDS_SECRETNAME | mysql-backup-creds | Name of secret |
 | HOUR | 3 |cron-syntax backup hour |
 | KEEP_DAYS | 31 | days of snapshots to keep |

--- a/images/mysqldump/README.md
+++ b/images/mysqldump/README.md
@@ -86,6 +86,17 @@ data:
 
 ### Notes
 
+Successful completion of dumps is indicated by updates to the file `mysqldump-status.txt`: if that file's age exceeds 24+ hours, look for failures. If the dump files are complete but storage rapidly runs out because `zstd` or `bzip2` didn't run, run the script manually (using the commands seen in `crontab -l -u mysqldump` from a root shell within the container) and check for errors such as the following:
+```
+mariadb-dump: Got error: 1044: "Access denied for user 'bkp'@'%' to database 'rsnap'" when using LOCK TABLES
+mariadb-dump: Couldn't execute 'show events': Access denied for user 'bkp'@'%' to database 'rsnap' (1044)
+```
+or
+```
+mariadb-dump: Couldn't execute 'SHOW FUNCTION STATUS WHERE Db = 'test'': Column count of mysql.proc is wrong. Expected 22, found 21. Created with MariaDB 120002, now running 120302. Please use mariadb-upgrade to fix this error (1558)
+```
+You may need to grant permissions or run the `mariadb-upgrade` maintenance command on your database, if anything has recently changed on the server.
+
 Dumps run in parallel in order to use available multi-core CPUs
 (mainly for compression). You can limit the number of simultaneous
 runs by changing the value of SKEW_SECONDS, so if your server has many

--- a/images/mysqldump/entrypoint.sh
+++ b/images/mysqldump/entrypoint.sh
@@ -11,10 +11,20 @@ echo [client] > $CNF
 cat /run/secrets/$DB_CREDS_SECRETNAME >> $CNF
 [ $SKIP_SSL = true ] && echo "skip-ssl=true" >> $CNF
 
+[ -z "$COMPRESS" ] && COMPRESS=bzip2
+
+cat <<EOF >/home/$USERNAME/.profile
+export COMPRESS="$COMPRESS"
+export COMPRESSLEVEL=$COMPRESSLEVEL
+export COMPRESSOPTS="$COMPRESSOPTS"
+export SKEW_SECONDS=$SKEW_SECONDS
+EOF
+
 touch $LOG
-chown $USERNAME /var/backup $LOG $CNF
+chown $USERNAME /var/backup $LOG $CNF /home/$USERNAME/.profile
 chmod 400 $CNF
-echo "$MINUTE $HOUR * * *   /usr/local/bin/mysql-backup.sh $KEEP_DAYS $SERVERS" \
+echo "$MINUTE $HOUR * * *   . /home/$USERNAME/.profile && \
+   /usr/local/bin/mysql-backup.sh $KEEP_DAYS $SERVERS" \
    | crontab -u $USERNAME -
 
 crond

--- a/images/mysqldump/helm/Chart.yaml
+++ b/images/mysqldump/helm/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/mariadb/server/tree/10.5/client
 type: application
-version: 0.1.18
+version: 0.1.19
 appVersion: "11.8.8-r0"
 dependencies:
 - name: chartlib

--- a/images/mysqldump/helm/values.yaml
+++ b/images/mysqldump/helm/values.yaml
@@ -1,6 +1,9 @@
 # Default values for mysqldump.
 deployment:
   env:
+    compress: zstd
+    compresslevel: "5"
+    compressopts: "--rm -fq"
     hour: "5"
     servers: db00
     skew_seconds: "30"

--- a/images/mysqldump/mysql-backup.sh
+++ b/images/mysqldump/mysql-backup.sh
@@ -26,6 +26,12 @@ log_entry () {
 log_entry info START
 
 [ -z "$LOCK_FOR_BACKUP" ] || OPT_LOCK_FOR_BACKUP=--lock-for-backup
+[ -z "$COMPRESS" ] && COMPRESS=bzip2
+[ -z "$COMPRESSLEVEL" ] && COMPRESSLEVEL=5
+[ -z "$COMPRESSOPTS" ] && COMPRESSOPTS=-f
+[ -z "$OLD_EXT" ] && OLD_EXT="bz2"
+[ -z "$SKEW_SECONDS" ] && SKEW_SECONDS=15
+COMPRESS="$COMPRESS $COMPRESSOPTS -$COMPRESSLEVEL"
 
 # Grants required for bkp user:
 # GRANT SELECT,RELOAD,SUPER,REPLICATION CLIENT ON *.* TO '$USER'@'192.168.%' IDENTIFIED BY '$PSWD';
@@ -38,10 +44,6 @@ DBNAME_QUERY="SELECT schema_name FROM information_schema.schemata \
  WHERE schema_name NOT IN ('sys','information_schema','performance_schema')"
 
 DESTDIR=/var/backup/mysql
-COMPRESS="bzip2 -f"
-COMPRESS_EXT="bz2"
-OLD_EXT="gz"
-[ "$SKEW_SECONDS" = "" ] && SKEW_SECONDS=15
 
 if [ "$#" -eq "0" ]; then
     echo "Usage: backup_mysql_all <days to keep> <list: instances>"

--- a/k8s/helm/immich/Chart.yaml
+++ b/k8s/helm/immich/Chart.yaml
@@ -6,7 +6,7 @@ sources:
 - https://github.com/immich-app/immich
 - https://github.com/instantlinux/docker-tools
 type: application
-version: 0.1.0
+version: 0.1.1
 # Reminder, update tag for ml instance in values.yaml
 appVersion: v3.0.1
 dependencies:

--- a/k8s/helm/immich/values.yaml
+++ b/k8s/helm/immich/values.yaml
@@ -39,10 +39,10 @@ deployment:
   resources:
     limits:
       cpu: 4000m
-      memory: 6144Mi
+      memory: 8192Mi
     requests:
       cpu: 1100m
-      memory: 768Mi
+      memory: 1024Mi
   nodeSelector:
     service.immich: allow
   strategy:


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Adds zstd package and variables COMPRESS, COMPRESSLEVEL and COMPRESSOPTS to the mysqldump docker image
* Bumps version of immich in its helm chart, to 3.0.1.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Bzip2 has gotten a bit out of date, even though it's in the alpine base image. Making a newer compression utility the default, now that it's 2026, seems necessary.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Manual testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
