### PR TITLE
SYS-694 fix weewx error message PyMapping_HasKeyString

### DIFF
--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,3 +1,3 @@
-ansible==12.3.0
-ansible-lint==26.1.1
-pip==26.1
+ansible==14.2.0
+ansible-lint==26.6.0
+pip==26.1.2

--- a/ansible/roles/bind9/tasks/main.yml
+++ b/ansible/roles/bind9/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install system packages
   apt:
     name: "{{ ubuntu_packages }}"
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: bind9 config
   template:

--- a/ansible/roles/docker_node/defaults/main.yml
+++ b/ansible/roles/docker_node/defaults/main.yml
@@ -6,7 +6,7 @@ docker_defaults:
     key: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
     package_name: docker-ce
     package_ver: 5:29.6.1-1~ubuntu.26.04~resolute
-    repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
+    repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_facts['distribution_release'] }} stable
     url: https://download.docker.com/linux/ubuntu/gpg
   certs:
     ca_root: ca-root.pem
@@ -74,9 +74,9 @@ ubuntu_packages:
 ubuntu_repo_uri: http://archive.ubuntu.com/ubuntu/
 
 ubuntu_repos:
-  - deb {{ ubuntu_repo_uri }} {{ ansible_distribution_release }} main restricted universe multiverse
-  - deb {{ ubuntu_repo_uri }} {{ ansible_distribution_release }}-updates main restricted universe multiverse
-  - deb {{ ubuntu_repo_uri }} {{ ansible_distribution_release }}-backports main restricted universe multiverse
-  - deb {{ ubuntu_repo_uri }} {{ ansible_distribution_release }}-security main restricted universe multiverse
+  - deb {{ ubuntu_repo_uri }} {{ ansible_facts['distribution_release'] }} main restricted universe multiverse
+  - deb {{ ubuntu_repo_uri }} {{ ansible_facts['distribution_release'] }}-updates main restricted universe multiverse
+  - deb {{ ubuntu_repo_uri }} {{ ansible_facts['distribution_release'] }}-backports main restricted universe multiverse
+  - deb {{ ubuntu_repo_uri }} {{ ansible_facts['distribution_release'] }}-security main restricted universe multiverse
 
 ubuntu_package_additions: []

--- a/ansible/roles/docker_node/tasks/docker.yml
+++ b/ansible/roles/docker_node/tasks/docker.yml
@@ -152,7 +152,7 @@
     mode: 0755
     url: https://github.com/docker/compose/releases/download/{{
       docker.compose.version }}/docker-compose-Linux-x86_64
-  when: ansible_distribution_version < '22.04'
+  when: ansible_facts['distribution_version'] < '22.04'
 
 - name: Sysctl tuning parameters
   ansible.builtin.sysctl:

--- a/ansible/roles/docker_node/tasks/packages.yml
+++ b/ansible/roles/docker_node/tasks/packages.yml
@@ -12,9 +12,9 @@
 - name: Python pip package
   apt:
     name: python3-pip
-  when: ansible_distribution_version >= '20.04'
+  when: ansible_facts['distribution_version'] >= '20.04'
 
 - name: Python pip package
   apt:
     name: python-pip
-  when: ansible_distribution_release < '20.04'
+  when: ansible_facts['distribution_release'] < '20.04'

--- a/ansible/roles/fileserver/defaults/main.yml
+++ b/ansible/roles/fileserver/defaults/main.yml
@@ -12,7 +12,7 @@ samba_defaults:
   hosts_allow: []
   interfaces:
   - lo
-  - "{{ ansible_default_ipv4.address }}"
+  - "{{ ansible_facts['default_ipv4']['address'] }}"
   log_level: 1
   logon_drive: H
   server_min_protocol: ""

--- a/ansible/roles/fileserver/tasks/main.yml
+++ b/ansible/roles/fileserver/tasks/main.yml
@@ -2,17 +2,17 @@
 - name: Install system packages
   apt:
     name: "{{ ubuntu_packages }}"
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Python pip package
   apt:
     name: python3-pip
-  when: ansible_distribution_version >= '20.04'
+  when: ansible_facts['distribution_version'] >= '20.04'
 
 - name: Python pip package
   apt:
     name: python-pip
-  when: ansible_distribution_version < '20.04'
+  when: ansible_facts['distribution_version'] < '20.04'
 
 - import_tasks: nfs.yml
   when: nfs_exports | length > 0

--- a/ansible/roles/fileserver/tasks/virtualbox.yml
+++ b/ansible/roles/fileserver/tasks/virtualbox.yml
@@ -11,18 +11,18 @@
   apt_repository:
     repo: >
       deb [arch=amd64 signed-by=/etc/apt/keyrings/oracle_vbox_2016.asc]
-      {{ virtualbox.apt_repo.url }} {{ ansible_distribution_release }} contrib
+      {{ virtualbox.apt_repo.url }} {{ ansible_facts['distribution_release }} contrib
     filename: virtualbox
 
 - name: Virtualbox package
   package:
     name: virtualbox
-  when: ansible_distribution_version < '22.04'
+  when: ansible_facts['distribution_version'] < '22.04'
 
 - name: Virtualbox package
   package:
     name: virtualbox-{{ virtualbox.version }}
-  when: ansible_distribution_version >= '22.04'
+  when: ansible_facts['distribution_version'] >= '22.04'
 
 - name: Virtualbox systemd unit file
   template:

--- a/ansible/roles/fileserver/templates/smb.conf.j2
+++ b/ansible/roles/fileserver/templates/smb.conf.j2
@@ -8,9 +8,9 @@
         logon home = \\%L\%U\.9xprofile
         logon path = \\%L\profiles\.msprofile
         map to guest = Bad Password
-        netbios name = {{ ansible_hostname }}
+        netbios name = {{ ansible_facts['hostname'] }}
         security = user
-        server string = {{ ansible_hostname }}--{{ samba.server_string }}
+        server string = {{ ansible_facts['hostname'] }}--{{ samba.server_string }}
         usershare max shares = 0
         workgroup = {{ samba.workgroup }}
 {% if samba.hosts_allow|length %}

--- a/ansible/roles/monitoring_agent/defaults/main.yml
+++ b/ansible/roles/monitoring_agent/defaults/main.yml
@@ -9,11 +9,11 @@ journald_conf: "{{ journald_conf_defaults | combine(journald_conf_override) }}"
 nagios_defaults:
   allowed_hosts:
   - localhost
-  nrpe_cfg: "{{ '/etc/nagios' if ansible_os_family == 'Debian' else '/etc'
+  nrpe_cfg: "{{ '/etc/nagios' if ansible_facts['os_family'] == 'Debian' else '/etc'
     }}/nrpe.cfg"
-  nrpe_path: /etc/{{ 'nagios' if ansible_os_family == 'Debian'
+  nrpe_path: /etc/{{ 'nagios' if ansible_facts['os_family'] == 'Debian'
     else 'nrpe.d' }}/nrpe_local.cfg
-  nrpe_service: "{{ 'nagios-nrpe-server' if ansible_os_family == 'Debian'
+  nrpe_service: "{{ 'nagios-nrpe-server' if ansible_facts['os_family'] == 'Debian'
     else 'nrpe' }}"
   nrpe_user: nagios
   local_plugins_path: /usr/local/lib/nagios

--- a/ansible/roles/monitoring_agent/tasks/packages.yml
+++ b/ansible/roles/monitoring_agent/tasks/packages.yml
@@ -8,7 +8,7 @@
 - name: Install extra packages
   ansible.builtin.apt:
     name: "{{ ubuntu_packages_extra }}"
-  when: ansible_distribution_version >= '18.04'
+  when: ansible_facts['distribution_version'] >= '18.04'
 
 - name: Python packages for monitoring
   ansible.builtin.command: pip3 install --break-system-packages {{

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -4,10 +4,10 @@
     name: "{{ ubuntu_packages }}"
 
 - import_tasks: network_legacy.yml
-  when: ansible_distribution_version < '18.04'
+  when: ansible_facts['distribution_version'] < '18.04'
 
 - import_tasks: netplan.yml
-  when: ansible_distribution_version >= '18.04'
+  when: ansible_facts['distribution_version'] >= '18.04'
 
 - import_tasks: kernel.yml
 - import_tasks: sshd.yml

--- a/ansible/roles/ntp/defaults/main.yml
+++ b/ansible/roles/ntp/defaults/main.yml
@@ -12,7 +12,7 @@ ntp_defaults:
   - 1.pool.ntp.org
   service:
     enabled: yes
-    name: "{{ 'ntpd-rs' if ansible_os_family == 'Debian' else 'ntpd' }}"
+    name: "{{ 'ntpd-rs' if ansible_facts['os_family'] == 'Debian' else 'ntpd' }}"
     state: restarted
 
 ntp_override: {}

--- a/ansible/roles/ntp/tasks/main.yml
+++ b/ansible/roles/ntp/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Install system packages
   ansible.builtin.apt:
     name: "{{ ubuntu_packages }}"
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: NTP keys
   ansible.builtin.template:
@@ -17,20 +17,20 @@
     mode: 0440
     src: ntp.keys.j2
   notify: Restart ntpd
-  when: ntp.service.enabled and ansible_distribution_version < '24.04'
+  when: ntp.service.enabled and ansible_facts['distribution_version'] < '24.04'
 
 - name: NTP config
   ansible.builtin.template:
     dest: /etc/ntp.conf
     src: ntp.conf.j2
   notify: Restart ntpd
-  when: ntp.service.enabled and ansible_distribution_version < '24.04'
+  when: ntp.service.enabled and ansible_facts['distribution_version'] < '24.04'
 
 - name: Override directory for ntp-rs systemd unit file
   ansible.builtin.file:
     dest: /etc/systemd/system/ntpd-rs.service.d
     state: directory
-  when: ntp.service.enabled and ansible_distribution_version >= '24.04'
+  when: ntp.service.enabled and ansible_facts['distribution_version'] >= '24.04'
 
 - name: Allow ntp-rs to bind on port 123
   ansible.builtin.copy:
@@ -38,14 +38,14 @@
     content: |
       [Service]
       AmbientCapabilities=CAP_SYS_TIME CAP_NET_BIND_SERVICE
-  when: ntp.service.enabled and ansible_distribution_version >= '24.04'
+  when: ntp.service.enabled and ansible_facts['distribution_version'] >= '24.04'
 
 - name: ntp-rs config
   ansible.builtin.template:
     dest: /etc/ntpd-rs/ntp.toml
     src: ntp.toml.j2
   notify: Restart ntpd
-  when: ntp.service.enabled and ansible_distribution_version >= '24.04'
+  when: ntp.service.enabled and ansible_facts['distribution_version'] >= '24.04'
 
 - name: NTP service
   ansible.builtin.systemd:

--- a/ansible/roles/users/defaults/main.yml
+++ b/ansible/roles/users/defaults/main.yml
@@ -26,10 +26,10 @@ opensuse_google_auth_repo:
     repo: http://download.opensuse.org/distribution/leap/42.2/repo/oss/suse
 
 pam_package: "{{
-    'libpam-google-authenticator' if ansible_os_family == 'Debian' 
+    'libpam-google-authenticator' if ansible_facts['os_family'] == 'Debian' 
     else 'pam-google-authenticator' }}"
 
 ubuntu_repo_uri: http://archive.ubuntu.com/ubuntu/
 
 ubuntu_google_auth_repo:
-  - deb {{ ubuntu_repo_uri }} {{ ansible_distribution_release }} main restricted universe multiverse
+  - deb {{ ubuntu_repo_uri }} {{ ansible_facts['distribution_release'] }} main restricted universe multiverse

--- a/ansible/roles/users/tasks/packages.yml
+++ b/ansible/roles/users/tasks/packages.yml
@@ -9,14 +9,14 @@
   args:
     creates: /etc/zypp/repos.d/{{ item.name}}.repo
   with_items: "{{ opensuse_google_auth_repo }}"
-  when: ansible_os_family == 'Suse'
+  when: ansible_facts['os_family'] == 'Suse'
 
 - name: Ensure repositories available
   apt_repository:
     repo: "{{ item }}"
     filename: ubuntu
   with_items: "{{ ubuntu_google_auth_repo }}"
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install PAM module for google-authenticator
   package:

--- a/ansible/roles/volumes/tasks/encrypted.yml
+++ b/ansible/roles/volumes/tasks/encrypted.yml
@@ -40,7 +40,7 @@
       shell: >
         cryptsetup isLuks /dev/{{ item.value.vg }}/{{ item.key }} ||
         cryptsetup luksFormat --batch-mode --verbose --key-file={{
-          masterkey.path }}/keys/{{ ansible_hostname }}/{{
+          masterkey.path }}/keys/{{ ansible_facts['hostname'] }}/{{
           item.key }} /dev/{{ item.value.vg }}/{{ item.key }}
       register: luks_format
       changed_when: ("Command successful" in luks_format.stdout)
@@ -57,7 +57,7 @@
     - name: Crypt table entries
       lineinfile:
         line: "{{ 'luks-%-16s /dev/mapper/%s-%-16s %s/keys/%s/%-12s luks' % (
-              item.key, item.value.vg, item.key, masterkey.path, ansible_hostname,
+              item.key, item.value.vg, item.key, masterkey.path, ansible_facts['hostname'],
               item.key) }}"
         path: /etc/crypttab.setup
         regexp: "^luks-{{ item.key }}.*"

--- a/ansible/roles/volumes/tasks/main.yml
+++ b/ansible/roles/volumes/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Install system packages
   ansible.builtin.apt:
     name: "{{ ubuntu_packages }}"
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Create mount points
   ansible.builtin.file:

--- a/images/weewx/Dockerfile
+++ b/images/weewx/Dockerfile
@@ -55,7 +55,7 @@ ARG AIRLINK_SHA=6392ee1d8e96a543306f16430ec9095b79dd7d0aacf8078171aa61b060a49745
 
 COPY install-input.txt entrypoint.sh log.conf /tmp
 RUN apk add --no-cache --update \
-      curl freetype libjpeg libstdc++ openssh openssl python3 py3-cheetah \
+      curl freetype libjpeg libstdc++ openssh openssl python3 \
       py3-configobj py3-mysqlclient py3-pillow py3-pymysql py3-pyserial \
       py3-requests py3-six py3-usb rsync rsyslog tzdata && \
     adduser -u $WX_UID -s /bin/sh -G $WX_GROUP -D $WX_USER && \
@@ -64,7 +64,7 @@ RUN apk add --no-cache --update \
     VENV=/home/$WX_USER/weewx-venv && \
     python3 -m venv $VENV --system-site-packages && \
     source $VENV/bin/activate && \
-    python3 -m pip install weewx==$WEEWX_VERSION && \
+    python3 -m pip install weewx==$WEEWX_VERSION ct3 && \
     git clone -b $WEEGREEN_VERSION --depth 1 \
       https://github.com/instantlinux/weewx-WeeGreen.git \
       $WX_ROOT/skins/WeeGreen && \


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
For the weewx image, this replaces py3 cheetah package with ct3 version 3.4.0, to get rid of this error seen in 5.4.0 image's logs:
```
Exception ignored in PyMapping_HasKeyString(); consider using PyMapping_HasKeyStringWithError(), PyMapping_GetOptionalItemString() or PyMapping_GetItemString():
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: string indices must be integers, not 'str'
```
A dependabot alert flagged some of the ansible dependencies, so the rest of this PR addresses the ansible-upgrade treadmill: this time the deprecation requires replacing dozens of `ansible_foo` variable references with `ansible_facts['foo']`, apparently for entirely gratuitous reasons intended to force extra maintenance burden upon those of us who chose ansible in the first place. (Yeah, this is ridiculous.)

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Routine dependency updates. Thanks but no thanks AI, we now run faster on the upgrade treadmill.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Local testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
