### PR TITLE
SYS-652 stop the prometheus deluge from node-exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ The cluster-deployment tools here include helm charts and ansible playbooks to s
 | mysqldump | [![](https://img.shields.io/docker/v/instantlinux/mysqldump?sort=date)](https://hub.docker.com/r/instantlinux/mysqldump "Version badge") | per-database alternative to xtrabackup |
 | nagios | [![](https://img.shields.io/docker/v/instantlinux/nagios?sort=date)](https://hub.docker.com/r/instantlinux/nagios "Version badge") | Nagios Core v4 for monitoring |
 | nagiosql | [![](https://img.shields.io/docker/v/instantlinux/nagiosql?sort=date)](https://hub.docker.com/r/instantlinux/nagiosql "Version badge") | NagiosQL for configuring Nagios Core v4 |
-| nextcloud | ** | mobile device sync, like Apple iCloud |
 | node-local-dns | ** | caching resolver for reliable pod DNS |
 | nut-upsd | [![](https://img.shields.io/docker/v/instantlinux/nut-upsd?sort=date)](https://hub.docker.com/r/instantlinux/nut-upsd "Version badge") | Network UPS Tools |
 | openldap | [![](https://img.shields.io/docker/v/instantlinux/openldap?sort=date)](https://hub.docker.com/r/instantlinux/openldap "Version badge") | OpenLDAP authentication server |

--- a/ansible/roles/monitoring_agent/defaults/main.yml
+++ b/ansible/roles/monitoring_agent/defaults/main.yml
@@ -67,6 +67,16 @@ pip_packages:
   # - click>=6.0
   - mdstat>=1.0.4
 
+prometheus_defaults:
+  exporter_enabled: true
+  exporter_args: "--collector.filesystem.mount-points-exclude=\
+    '^/(dev|proc|sys|var/lib/kubelet|var/lib/docker/(containers|overlay2).+)($|/)' \
+    --collector.netdev.device-exclude='^(veth.*|docker.*)$' \
+    --collector.netclass.ignored-devices='^(veth.*|docker.*)$' \
+    --no-collector.systemd"
+prometheus_override: {}
+prometheus: "{{ prometheus_defaults | combine(prometheus_override) }}"
+
 smartmon_download:
   version: "7.1"
   checksum: 3f734d2c99deb1e4af62b25d944c6252de70ca64d766c4c7294545a2e659b846

--- a/ansible/roles/monitoring_agent/handlers/main.yml
+++ b/ansible/roles/monitoring_agent/handlers/main.yml
@@ -21,5 +21,10 @@
     name: snmpd
     state: restarted
 
+- name: Restart prometheus-node-exporter
+  ansible.builtin.service:
+    name: prometheus-node-exporter
+    state: restarted
+
 - name: Reload apparmor
   ansible.builtin.command: apparmor_parser -r /etc/apparmor.d/usr.sbin.rsyslogd

--- a/ansible/roles/monitoring_agent/tasks/main.yml
+++ b/ansible/roles/monitoring_agent/tasks/main.yml
@@ -89,3 +89,12 @@
   ansible.builtin.template:
     dest: "{{ nagios.local_plugins_path }}/tolerations.yaml"
     src: tolerations.j2
+
+- name: Put a leash on prometheus-node-exporter
+  ansible.builtin.copy:
+    dest: /etc/default/prometheus-node-exporter
+    content: |
+      # Managed by ansible
+      ARGS="{{ prometheus.exporter_args }}"
+  notify: Restart prometheus-node-exporter
+  when: prometheus.exporter_enabled

--- a/k8s/helm/grafana/Chart.yaml
+++ b/k8s/helm/grafana/Chart.yaml
@@ -6,8 +6,9 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://github.com/grafana/grafana
 type: application
-version: 0.1.4
-appVersion: 13.0.3
+version: 0.1.5
+# Reminder, update subchart tags in values.yaml
+appVersion: 13.0.6
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/k8s/helm/grafana/values.yaml
+++ b/k8s/helm/grafana/values.yaml
@@ -96,5 +96,9 @@ ingressTOTP:
 # Subchart parameters
 prometheus:
   enabled: true
+  image:
+    tag: v3.13.2
 alertmanager:
   enabled: true
+  image:
+    tag: v0.33.1


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Improvements to ansible role `monitoring_agent` and helm chart `grafana`.

* Add flags to block metrics from docker volumes and network devices
* Block systemd metrics (why would anyone ever want those? So voluminous!)
* Update image tags for grafana and its subcharts

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Got tired of constantly enlarging the prometheus storage volume.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Manual testing.

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
