### PR TITLE
SYS-699 add lightweight msmtp agent; add BIND_IP option for garage

### DIFF
--- a/ansible/roles/network/defaults/main.yml
+++ b/ansible/roles/network/defaults/main.yml
@@ -33,6 +33,18 @@ network: "{{ network_defaults | combine(network_override, recursive=True) }}"
 network_sysctl:
   net.ipv4.ip_nonlocal_bind: 1
 
+msmtp_defaults:
+  enabled: false
+  config:
+    defaults: ""
+    syslog: LOG_MAIL
+    account: default
+    host: smtp
+    port: 587
+    from: root
+msmtp_override: {}
+msmtp: "{{ msmtp_defaults | combine(msmtp_override, recursive=True) }}"
+
 sshd_opts_defaults:
   ciphers:
   - aes128-cbc

--- a/ansible/roles/network/tasks/main.yml
+++ b/ansible/roles/network/tasks/main.yml
@@ -14,3 +14,6 @@
 
 - import_tasks: kernel.yml
 - import_tasks: sshd.yml
+
+- import_tasks: msmtp.yml
+  when: msmtp.enabled

--- a/ansible/roles/network/tasks/msmtp.yml
+++ b/ansible/roles/network/tasks/msmtp.yml
@@ -1,0 +1,19 @@
+---
+- name: Install msmtp-mta
+  ansible.builtin.apt:
+    name: msmtp-mta
+    state: present
+
+- name: Configure msmtp
+  ansible.builtin.copy:
+    dest: /etc/msmtprc
+    content: |
+      # Managed by ansible
+      {% for key, val in msmtp.config.items() %}
+      {{ key }} {{ val }}
+      {% endfor %}
+
+- name: Remove postfix
+  ansible.builtin.apt:
+    name: postfix
+    state: absent

--- a/images/data-sync/helm/values.yaml
+++ b/images/data-sync/helm/values.yaml
@@ -105,19 +105,15 @@ configmap:
       ignore = Name ldapi
       ignore = Name lost+found
       ignore = Name msg.sock
-      # jenkins
-      ignore = Name *KubernetesClients.log
       ignore = Name *socket
       ignore = Name .s.PGSQL.5432
       ignore = Name atlassian-*.log
       ignore = Name pgstat.stat
-      ignore = Path data-sync/share/artifactory/data/data/derby/log
-      ignore = Path data-sync/share/artifactory/data/logs/request.log
+      ignore = Path data-sync/share/headscale/db.sqlite-shm
       ignore = Path data-sync/share/nagios/var/rw
       ignore = Path data-sync/share/openldap/data/lock.mdb
       ignore = Path data-sync/share/snappymail/data/_default_/cache
       ignore = Path data-sync/dos
-      ignore = Path data-sync/headscale/db.sqlite-shm
       ignore = Path data-sync/home/*/.kube/cache
       ignore = Path data-sync/jira/home/analytics-logs
       ignore = Path data-sync/jira/home/log/automation-jira-performance.csv
@@ -142,8 +138,6 @@ configmap:
       auto   = true
       batch  = true
       confirmbigdel = true
-      # copyquoterem feature seems to be gone as of 2.53.3
-      ## copyquoterem = false
       # SYS-400 overall performance is absolutely awful without this
       fastercheckUNSAFE = true
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -96,7 +96,7 @@ install: install/admin-user cluster_network \
 	install_imports namespace_config install/prometheus-rbac \
 	install/k8s-backup fluent-bit remote_volumes \
 	sops data-sync-ssh persistent secrets install/ingress-nginx \
-	install/cert-manager
+	install/rsyslog-ext install/cert-manager
 
 namespace_config: install/namespace install/limits install/namespace-user \
 	secrets/regcred

--- a/k8s/Makefile.vars
+++ b/k8s/Makefile.vars
@@ -38,9 +38,11 @@ export RSYSLOGD_IP          ?= 10.101.1.40
 export COREDNS_IP           ?= 10.96.0.10
 export NODE_LOCAL_DNS_IP    ?= 169.254.0.10
 
-# Exposed nodePorts - install/ingress-nginx.yaml
+# Exposed nodePorts - install/ingress-nginx.yaml, install/rsyslog-ext.yaml
 export NODEPORT_HTTP         ?= 30080
 export NODEPORT_HTTPS        ?= 30443
+export NODEPORT_SYSLOG       ?= 30514
+
 # Ports configured in ingress-nginx.yaml
 export PORT_DOVECOT_IMAPD    ?= 843
 export PORT_DOVECOT_IMAPS    ?= 993

--- a/k8s/helm/grafana/values.yaml
+++ b/k8s/helm/grafana/values.yaml
@@ -37,10 +37,10 @@ deployment:
     failureThreshold: 10
   resources:
     limits:
-      memory: 256Mi
+      memory: 1024Mi
     requests:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi
 volumeMounts:
 - mountPath: /var/lib/grafana
   name: data

--- a/k8s/helm/headscale/values.yaml
+++ b/k8s/helm/headscale/values.yaml
@@ -19,6 +19,9 @@ deployment:
   containerPorts:
   - containerPort: 8080
   - containerPort: 9090
+  - containerPort: 3478
+    protocol: UDP
+    name: stun
   resources:
     limits:
       memory: 512Mi
@@ -52,6 +55,8 @@ service:
   clusterIP: None
   ports:
   - { port: 8080, targetPort: 8080, name: headscale }
+  - { port: 3478, targetPort: 3478, name: stun, protocol: UDP }
+  - { port: 41641, targetPort: 41461, name: wireguard, protocol: UDP }
   type: ClusterIP
 
 ingress:
@@ -102,17 +107,17 @@ configmap:
       derp:
         server:
           enabled: false
-        region_id: 999
-        region_code: "headscale"
-        region_name: "Headscale Embedded DERP"
-        stun_listen_addr: "0.0.0.0:3478"
-        private_key_path: /var/lib/headscale/derp_server_private.key
-        automatically_add_embedded_derp_region: true
+          region_id: 999
+          region_code: "headscale"
+          region_name: "Headscale Embedded DERP"
+          stun_listen_addr: "0.0.0.0:3478"
+          private_key_path: /var/lib/headscale/derp_server_private.key
+          automatically_add_embedded_derp_region: true
         urls:
         - https://controlplane.tailscale.com/derpmap/default
         paths: []
         auto_update_enabled: true
-        update_frequency: 3h
+        update_frequency: 24h
       disable_check_updates: false
       node:
         expire: 0

--- a/k8s/install/rsyslog-ext.yaml
+++ b/k8s/install/rsyslog-ext.yaml
@@ -1,0 +1,14 @@
+---
+# for remote VPN-connected systems
+apiVersion: v1
+kind: Service
+metadata:
+  name: rsyslogd-external
+  namespace: $K8S_NAMESPACE
+spec:
+  type: NodePort
+  ports:
+  - { port: 514, nodePort: $NODEPORT_SYSLOG, targetPort: 514, name: rsyslogd }
+  selector:
+    app.kubernetes.io/name: rsyslogd
+  sessionAffinity: ClientIP

--- a/services/garage/docker-compose.yml
+++ b/services/garage/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     volumes:
       - webui-data:/data # required: user accounts, audit logs, upload temp files
     ports:
-      - 3909:3909
+      - ${GARAGE_BIND_IP:-[::]}:3909:3909
     environment:
       API_BASE_URL: "http://${GARAGE_HOST:-localhost}:3903"
       S3_ENDPOINT_URL: "http://${GARAGE_HOST:-}:3900"
@@ -57,20 +57,20 @@ configs:
 
       consistency_mode = "consistent"
       replication_factor = 1
-      rpc_bind_addr = "[::]:3901"
+      rpc_bind_addr = "${GARAGE_BIND_IP:-[::]}:3901"
       rpc_public_addr = "127.0.0.1:3901"
       compression_level = 2
 
       [s3_api]
       s3_region = "${GARAGE_REGION:-garage}"
-      api_bind_addr = "[::]:3900"
+      api_bind_addr = "${GARAGE_BIND_IP:-[::]}:3900"
       root_domain = "api.${GARAGE_DOMAIN:-s3.garage.localhost}"
 
       [s3_web]
-      bind_addr = "[::]:3902"
+      bind_addr = "${GARAGE_BIND_IP:-[::]}:3902"
       root_domain = "web.${GARAGE_DOMAIN:-s3.garage.localhost}"
       index = "index.html"
 
       [admin]
-      api_bind_addr = "0.0.0.0:3903"
+      api_bind_addr = "${GARAGE_BIND_IP:-[::]}:3903"
       admin_token = "${GARAGE_ADMIN_TOKEN:-****}"


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Email server is an attack surface that is unnecessary on infra servers (fileservers, k8s workers etc). Provide msmtp, a client-only alternative to postfix.

This also adds a bind-ip parameter for launching garage S3-compatible server under docker-compose (to put it behind a VPN, for example).

Housekeeping tweaks:
* Bump default RAM under k8s for grafana helm chart
* Clean a couple of old settings, and add one for headscale, in the data-sync chart's default file exclusion list
* Add a nodePort 30514 for ingesting syslog over the VPN

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
General security improvements.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Manual testing

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
