### PR TITLE
SYS-701 pipeline broke after docker buildx 0.30.1 fully deprecated on gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ workflow:
   - { if: $CI_COMMIT_TAG =~ /^chart-.*/, when: never }
   - when: always
 
-image: docker:29.7.2
+image: docker:29.6.2
 
 prepare:
   stage: prepare

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ workflow:
   - { if: $CI_COMMIT_TAG =~ /^chart-.*/, when: never }
   - when: always
 
-image: docker:29.6.2
+image: docker:29.7.2
 
 prepare:
   stage: prepare

--- a/.image-gitlab-ci.yml
+++ b/.image-gitlab-ci.yml
@@ -79,7 +79,7 @@ security_scan_trivy:
   artifacts:
     reports:
       container_scanning: gl-container-scanning-report.json
-    expire_in: 30 days
+    expire_in: 90 days
     paths: [ medium-vulns.txt ]
 
 promote_image:

--- a/.image-gitlab-ci.yml
+++ b/.image-gitlab-ci.yml
@@ -19,7 +19,7 @@ image: docker:29.7.2
   before_script:
   - export TAG=bld_$CI_PIPELINE_IID_${CI_COMMIT_SHORT_SHA}
   - docker login -u $CI_REGISTRY_USER -p $CI_JOB_TOKEN $REGISTRY
-  services: [ "docker:29.7.2-dind" ]
+  services: [ "docker:29.6.2-dind" ]
 
 analysis:
   stage: Static Code Analysis
@@ -30,14 +30,14 @@ create_image:
   <<: *registry_login
   stage: Create Image
   script: apk add make && cd images/$IMAGE && make create_image
-  services: [ { name: "docker:29.7.2-dind", command: ["--experimental"] } ]
+  services: [ { name: "docker:29.6.2-dind", command: ["--experimental"] } ]
 
 test:
   stage: Functional Tests
   script: apk add make && cd images/$IMAGE && make test_functional
 
 security_scan_trivy:
-  services: [ "docker:29.7.2-dind" ]
+  services: [ "docker:29.6.2-dind" ]
   image:
     name: aquasec/trivy:$TRIVY_VERSION
     entrypoint: [""]

--- a/.image-gitlab-ci.yml
+++ b/.image-gitlab-ci.yml
@@ -19,7 +19,7 @@ image: docker:29.7.2
   before_script:
   - export TAG=bld_$CI_PIPELINE_IID_${CI_COMMIT_SHORT_SHA}
   - docker login -u $CI_REGISTRY_USER -p $CI_JOB_TOKEN $REGISTRY
-  services: [ "docker:29.6.2-dind" ]
+  services: [ "docker:dind" ]
 
 analysis:
   stage: Static Code Analysis
@@ -30,14 +30,14 @@ create_image:
   <<: *registry_login
   stage: Create Image
   script: apk add make && cd images/$IMAGE && make create_image
-  services: [ { name: "docker:29.6.2-dind", command: ["--experimental"] } ]
+  services: [ { name: "docker:dind", command: ["--experimental"] } ]
 
 test:
   stage: Functional Tests
   script: apk add make && cd images/$IMAGE && make test_functional
 
 security_scan_trivy:
-  services: [ "docker:29.6.2-dind" ]
+  services: [ "docker:dind" ]
   image:
     name: aquasec/trivy:$TRIVY_VERSION
     entrypoint: [""]

--- a/.image-gitlab-ci.yml
+++ b/.image-gitlab-ci.yml
@@ -13,13 +13,13 @@ stages:
   - Security Scan
   - Promote Image
 
-image: docker:29.6.2
+image: docker:29.7.2
 
 .registry_template: &registry_login
   before_script:
   - export TAG=bld_$CI_PIPELINE_IID_${CI_COMMIT_SHORT_SHA}
   - docker login -u $CI_REGISTRY_USER -p $CI_JOB_TOKEN $REGISTRY
-  services: [ "docker:dind" ]
+  services: [ "docker:29.7.2-dind" ]
 
 analysis:
   stage: Static Code Analysis
@@ -30,14 +30,14 @@ create_image:
   <<: *registry_login
   stage: Create Image
   script: apk add make && cd images/$IMAGE && make create_image
-  services: [ { name: "docker:dind", command: ["--experimental"] } ]
+  services: [ { name: "docker:29.7.2-dind", command: ["--experimental"] } ]
 
 test:
   stage: Functional Tests
   script: apk add make && cd images/$IMAGE && make test_functional
 
 security_scan_trivy:
-  services: [ "docker:dind" ]
+  services: [ "docker:29.7.2-dind" ]
   image:
     name: aquasec/trivy:$TRIVY_VERSION
     entrypoint: [""]

--- a/.image-gitlab-ci.yml
+++ b/.image-gitlab-ci.yml
@@ -13,7 +13,7 @@ stages:
   - Security Scan
   - Promote Image
 
-image: docker:29.7.2
+image: docker:29.6.2
 
 .registry_template: &registry_login
   before_script:

--- a/lib/build/Makefile.docker_image
+++ b/lib/build/Makefile.docker_image
@@ -1,7 +1,7 @@
 # Standard Makefile for Docker image
 #   created by richb@instantlinux.net 20-Apr-2017
 
-BUILDX      = https://github.com/docker/buildx/releases/download/v0.36.1/buildx-v0.30.1.linux-amd64
+BUILDX      = https://github.com/docker/buildx/releases/download/v0.36.1/buildx-v0.36.1.linux-amd64
 PLATFORMS  ?= linux/amd64
 PUSH       ?= --push
 USER_LOGIN ?= instantlinux

--- a/lib/build/Makefile.docker_image
+++ b/lib/build/Makefile.docker_image
@@ -1,7 +1,7 @@
 # Standard Makefile for Docker image
 #   created by richb@instantlinux.net 20-Apr-2017
 
-BUILDX      = https://github.com/docker/buildx/releases/download/v0.30.1/buildx-v0.30.1.linux-amd64
+BUILDX      = https://github.com/docker/buildx/releases/download/v0.36.1/buildx-v0.30.1.linux-amd64
 PLATFORMS  ?= linux/amd64
 PUSH       ?= --push
 USER_LOGIN ?= instantlinux


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
* Bump docker buildx version to `0.36.1`
* Keep gitlab trivy reports online for 90 days instead of 30

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Pipeline stopped working on GitLab when this error started appearing:
```
ERROR: failed to build: failed to solve: failed to push
 registry.gitlab.com/instantlinux/docker-tools/git-dump:bld_84829e32:
 unknown: blob unknown to registry
```
## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Pipeline testing

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
