### PR TITLE
SYS-701 switch ansible to deb822_repository; fix nagios image

### DIFF
--- a/ansible/roles/docker_node/defaults/main.yml
+++ b/ansible/roles/docker_node/defaults/main.yml
@@ -6,8 +6,7 @@ docker_defaults:
     key: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
     package_name: docker-ce
     package_ver: 5:29.7.2-1~ubuntu.26.04~resolute
-    repo: deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_facts['distribution_release'] }} stable
-    url: https://download.docker.com/linux/ubuntu/gpg
+    url: https://download.docker.com/linux/ubuntu
   certs:
     ca_root: ca-root.pem
     path: /root/certs
@@ -70,13 +69,6 @@ ubuntu_packages:
   - snmpd
   - thin-provisioning-tools
   - uuid-runtime
+ubuntu_package_additions: []
 
 ubuntu_repo_uri: http://archive.ubuntu.com/ubuntu/
-
-ubuntu_repos:
-  - deb {{ ubuntu_repo_uri }} {{ ansible_facts['distribution_release'] }} main restricted universe multiverse
-  - deb {{ ubuntu_repo_uri }} {{ ansible_facts['distribution_release'] }}-updates main restricted universe multiverse
-  - deb {{ ubuntu_repo_uri }} {{ ansible_facts['distribution_release'] }}-backports main restricted universe multiverse
-  - deb {{ ubuntu_repo_uri }} {{ ansible_facts['distribution_release'] }}-security main restricted universe multiverse
-
-ubuntu_package_additions: []

--- a/ansible/roles/docker_node/tasks/repos.yml
+++ b/ansible/roles/docker_node/tasks/repos.yml
@@ -1,16 +1,22 @@
 ---
 - name: Ensure ubuntu repos available
-  apt_repository:
-    repo: "{{ item }}"
-    filename: ubuntu
-  with_items: "{{ ubuntu_repos }}"
-
-- name: Docker repo key
-  get_url:
-    url: "{{ docker.apt_repo.url }}"
-    dest: /etc/apt/keyrings/docker.asc
+  deb822_repository:
+    name: ubuntu
+    types: [ deb, deb-src ]
+    uris: "{{ ubuntu_repo_uri }}"
+    suites:
+    - "{{ ansible_facts['distribution_release'] }}"
+    - "{{ ansible_facts['distribution_release'] }}-updates"
+    - "{{ ansible_facts['distribution_release'] }}-security"
+    - "{{ ansible_facts['distribution_release'] }}-backports"
+    components: [ main, restricted, universe, multiverse ]
+    signed_by: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 - name: Docker repo
-  apt_repository:
-    filename: docker
-    repo: "{{ docker.apt_repo.repo }}"
+  deb822_repository:
+    name: docker
+    types: [ deb ]
+    uris: "{{ docker.apt_repo.url }}"
+    suites: [ "{{ ansible_facts['distribution_release'] }}" ]
+    components: [ stable ]
+    signed_by: "{{ docker.apt_repo.url }}/gpg"

--- a/ansible/roles/docker_node/tasks/repos.yml
+++ b/ansible/roles/docker_node/tasks/repos.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure ubuntu repos available
-  deb822_repository:
+  ansible.builtin.deb822_repository:
     name: ubuntu
     types: [ deb, deb-src ]
     uris: "{{ ubuntu_repo_uri }}"
@@ -13,7 +13,7 @@
     signed_by: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 - name: Docker repo
-  deb822_repository:
+  ansible.builtin.deb822_repository:
     name: docker
     types: [ deb ]
     uris: "{{ docker.apt_repo.url }}"

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -14,8 +14,7 @@ k8s_defaults:
   config_fetch_always: false
   apt_repo:
     # TODO parameterize hardcoded 1.36 value
-    repo: deb [signed-by=/etc/apt/keyrings/kubernetes.asc] https://pkgs.k8s.io/core:/stable:/v1.36/deb/ /
-    url: https://pkgs.k8s.io/core:/stable:/v1.36/deb/Release.key
+    url: https://pkgs.k8s.io/core:/stable:/v1.36/deb
   cplane_hostip: "{{ hostvars[groups['k8s_cplane'][0]]['ansible_default_ipv4']['address'] | default(groups['k8s_cplane'][0]) }}"
   cplane_vip: "{{ hostvars[groups['k8s_cplane'][0]]['ansible_default_ipv4']['address'] | default(groups['k8s_cplane'][0]) }}"
   # TODO: might be able to retire cri-dockerd

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -1,13 +1,11 @@
 ---
-- name: k8s repo key
-  get_url:
-    url: "{{ k8s.apt_repo.url }}"
-    dest: /etc/apt/keyrings/kubernetes.asc
-
 - name: k8s repo
-  apt_repository:
-    filename: k8s
-    repo: "{{ k8s.apt_repo.repo }}"
+  deb822_repository:
+    name: k8s
+    types: [ deb ]
+    uris: "{{ k8s.apt_repo.url }}"
+    suites: [ / ]
+    signed_by: "{{ k8s.apt_repo.url }}/Release.key"
 
 - name: Install system packages
   apt:

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: k8s repo
-  deb822_repository:
+  ansible.builtin.deb822_repository:
     name: k8s
     types: [ deb ]
     uris: "{{ k8s.apt_repo.url }}"

--- a/ansible/roles/network/tasks/tailscale.yml
+++ b/ansible/roles/network/tasks/tailscale.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add Tailscale repository
-  deb822_repository:
+  ansible.builtin.deb822_repository:
     name: tailscale
     types: [ deb ]
     uris: https://pkgs.tailscale.com/stable/ubuntu

--- a/ansible/roles/network/tasks/tailscale.yml
+++ b/ansible/roles/network/tasks/tailscale.yml
@@ -1,15 +1,13 @@
 ---
-- name: Download Tailscale GPG Key
-  ansible.builtin.get_url:
-    dest: /usr/share/keyrings/tailscale-archive-keyring.gpg
-    url: https://pkgs.tailscale.com/stable/ubuntu/{{
-      ansible_facts['distribution_release'] }}.noarmor.gpg 
-
 - name: Add Tailscale repository
-  ansible.builtin.get_url:
-    dest: /etc/apt/sources.list.d/tailscale.list
-    url: https://pkgs.tailscale.com/stable/ubuntu/{{
-      ansible_facts['distribution_release'] }}.tailscale-keyring.list
+  deb822_repository:
+    name: tailscale
+    types: [ deb ]
+    uris: https://pkgs.tailscale.com/stable/ubuntu
+    suites: [ "{{ ansible_facts['distribution_release'] | lower }}" ]
+    components: [ main ]
+    signed_by: "https://pkgs.tailscale.com/stable/ubuntu//{{
+      ansible_facts['distribution_release'] }}.noarmor.gpg"
 
 - name: Install Tailscale
   ansible.builtin.apt:

--- a/ansible/roles/users/tasks/packages.yml
+++ b/ansible/roles/users/tasks/packages.yml
@@ -12,10 +12,12 @@
   when: ansible_facts['os_family'] == 'Suse'
 
 - name: Ensure repositories available
-  apt_repository:
-    repo: "{{ item }}"
-    filename: ubuntu
-  with_items: "{{ ubuntu_google_auth_repo }}"
+  deb822_repository:
+    name: ubuntu
+    types: [ deb ]
+    uris: "{{ ubuntu_repo_uri }}"
+    suites: [ "{{ ansible_facts['distribution_release'] }}" ]
+    components: [ main, restricted, universe, multiverse ]
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install PAM module for google-authenticator

--- a/ansible/roles/users/tasks/packages.yml
+++ b/ansible/roles/users/tasks/packages.yml
@@ -2,7 +2,7 @@
 # packages.yml
 
 - name: Zypper repository
-  command: >
+  ansible.builtin.command: >
     zypper addrepo
     {{ '--no-gpgcheck' if 'disable_gpg_check' in item else ''}}
     {{ item.repo }} {{ item.name }}
@@ -12,7 +12,7 @@
   when: ansible_facts['os_family'] == 'Suse'
 
 - name: Ensure repositories available
-  deb822_repository:
+  ansible.builtin.deb822_repository:
     name: ubuntu
     types: [ deb ]
     uris: "{{ ubuntu_repo_uri }}"
@@ -21,5 +21,5 @@
   when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install PAM module for google-authenticator
-  package:
+  ansible.builtin.package:
     name: "{{ pam_package }}"

--- a/images/nagios/entrypoint.sh
+++ b/images/nagios/entrypoint.sh
@@ -7,8 +7,8 @@ if [ ! -f /etc/timezone ] && [ ! -z "$TZ" ]; then
 fi
 
 sed -i -e "s/=nagiosadmin/=$AUTHORIZED_USERS/" /etc/nagios/cgi.cfg
-if [ -s /run/secrets/$HTPASSWD_SECRET ]; then
-  cp /run/secrets/$HTPASSWD_SECRET /etc/nagios/htpasswd.users
+if [ -s /run/secrets/$HTPASSWD_SECRETNAME ]; then
+  cp /run/secrets/$HTPASSWD_SECRETNAME /etc/nagios/htpasswd.users
   chown root:www-data /etc/nagios/htpasswd.users
   chmod 640 /etc/nagios/htpasswd.users
 fi

--- a/images/samba-dc/helm/Chart.yaml
+++ b/images/samba-dc/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - ttps://gitlab.com/samba-team/samba
 type: application
-version: 0.1.19
-appVersion: "4.23.8-r0"
+version: 0.1.20
+appVersion: "4.23.10-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8

--- a/images/samba/helm/Chart.yaml
+++ b/images/samba/helm/Chart.yaml
@@ -6,8 +6,8 @@ sources:
 - https://github.com/instantlinux/docker-tools
 - https://gitlab.com/samba-team/samba
 type: application
-version: 0.1.19
-appVersion: "4.23.8-r0"
+version: 0.1.20
+appVersion: "4.23.10-r0"
 dependencies:
 - name: chartlib
   version: 0.1.8


### PR DESCRIPTION
## Summary of Changes

<!-- (required) Describe the effects of your pull request in detail. If multiple
changes are involved, a bulleted list is often useful. -->
Replace old apt_key / apt_repo logic in the ansible roles with `ansible.builtin.deb822_repository` module.

Also correct an omission in the nagios image's entrypoint script.

## Why is this change being made?

<!-- (required) Describe the reasoning and background context for your
change. Include link(s) to relevant issue(s). -->
Housekeeping, to eliminate more references to deprecated ansible modules.

## How was this tested? How can the reviewer verify your testing?

<!-- (required) Describe the steps you used to reproduce the problem this change
fixes, and how to test your change. Provide explicit, repeatable instructions
the reviewer can follow to verify your testing. -->
Manual testing and CI

## Completion checklist

- [x] The pull request is linked to all related issues
- [x] This change has unit test coverage
- [x] Documentation has been updated
- [x] Dependencies have been updated and verified
